### PR TITLE
Add simple L25 compiler/interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 __pycache__
 *.pyc
+parsetab.py
+parser.out

--- a/l25/README.md
+++ b/l25/README.md
@@ -1,0 +1,31 @@
+# L25 Compiler (Python)
+
+This directory contains a simple interpreter for the L25 language written in Python using the [PLY](https://www.dabeaz.com/ply/) parsing library. The design isolates the lexer and parser so that it can be replaced by an ANTLR‑generated parser in the future.
+
+## Usage
+
+1. Install the dependency:
+   ```bash
+   pip install ply
+   ```
+2. Run a program:
+   ```bash
+   python -m l25.main path/to/source.l25
+   ```
+
+## Project Layout
+
+- `lexer.py` – token definitions and lexer implementation using PLY.
+- `parser.py` – grammar rules that produce an abstract syntax tree.
+- `ast_nodes.py` – dataclasses describing the AST nodes.
+- `interpreter.py` – executes the AST. Arrays are represented with Python lists, structs with dictionaries.
+- `main.py` – command line entry point.
+
+The parser and interpreter modules are decoupled from the lexer so that future work can plug in an ANTLR-based parser by implementing the same AST generation.
+
+## Testing
+
+A basic smoke test is provided in `tests/test_sample.py`. Run:
+```bash
+python l25/tests/test_sample.py
+```

--- a/l25/__init__.py
+++ b/l25/__init__.py
@@ -1,0 +1,4 @@
+from .parser import parse
+from .interpreter import eval_program
+
+__all__ = ["parse", "eval_program"]

--- a/l25/ast_nodes.py
+++ b/l25/ast_nodes.py
@@ -1,0 +1,100 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Any
+
+@dataclass
+class Program:
+    name: str
+    funcs: List['FuncDef']
+    main: 'Block'
+
+@dataclass
+class FuncDef:
+    name: str
+    params: List[str]
+    body: 'Block'
+    return_expr: 'Expr'
+
+@dataclass
+class Block:
+    statements: List['Stmt']
+
+@dataclass
+class StructDef:
+    name: str
+    fields: List[str]
+
+# --- Statements ---
+class Stmt:
+    pass
+
+@dataclass
+class Declare(Stmt):
+    name: str
+    expr: Optional['Expr'] = None
+
+@dataclass
+class Assign(Stmt):
+    target: 'Expr'
+    expr: 'Expr'
+
+@dataclass
+class If(Stmt):
+    condition: 'Expr'
+    then_block: Block
+    else_block: Optional[Block] = None
+
+@dataclass
+class While(Stmt):
+    condition: 'Expr'
+    body: Block
+
+@dataclass
+class FuncCallStmt(Stmt):
+    call: 'FuncCall'
+
+@dataclass
+class InputStmt(Stmt):
+    targets: List[str]
+
+@dataclass
+class OutputStmt(Stmt):
+    exprs: List['Expr']
+
+# --- Expressions ---
+class Expr:
+    pass
+
+@dataclass
+class BinaryOp(Expr):
+    op: str
+    left: Expr
+    right: Expr
+
+@dataclass
+class UnaryOp(Expr):
+    op: str
+    operand: Expr
+
+@dataclass
+class Number(Expr):
+    value: int
+
+@dataclass
+class Var(Expr):
+    name: str
+
+@dataclass
+class ArrayAccess(Expr):
+    array: str
+    index: Expr
+
+@dataclass
+class FieldAccess(Expr):
+    var: str
+    field: str
+
+@dataclass
+class FuncCall(Expr):
+    name: str
+    args: List[Expr]
+

--- a/l25/interpreter.py
+++ b/l25/interpreter.py
@@ -1,0 +1,130 @@
+from typing import Any, Dict, List
+from . import ast_nodes as ast
+
+
+class Environment:
+    def __init__(self, parent=None):
+        self.vars: Dict[str, Any] = {}
+        self.struct_defs: Dict[str, List[str]] = {}
+        self.parent = parent
+
+    def get(self, name: str):
+        if name in self.vars:
+            return self.vars[name]
+        if self.parent:
+            return self.parent.get(name)
+        raise NameError(f"Undefined variable {name}")
+
+    def set(self, name: str, value: Any):
+        env = self if name in self.vars or self.parent is None else self.parent
+        env.vars[name] = value
+
+
+def eval_program(prog: ast.Program):
+    global_env = Environment()
+    functions = {f.name: f for f in prog.funcs}
+
+    def call_func(func: ast.FuncDef, args: List[Any]):
+        local = Environment(global_env)
+        for name, value in zip(func.params, args):
+            local.vars[name] = value
+        res = eval_block(func.body, local)
+        return eval_expr(func.return_expr, local)
+
+    def eval_block(block: ast.Block, env: Environment):
+        for stmt in block.statements:
+            eval_stmt(stmt, env)
+
+    def eval_stmt(stmt: ast.Stmt, env: Environment):
+        if isinstance(stmt, ast.Declare):
+            value = eval_expr(stmt.expr, env) if stmt.expr else 0
+            env.vars[stmt.name] = value
+        elif isinstance(stmt, ast.Assign):
+            target = stmt.target
+            if isinstance(target, ast.Var):
+                env.set(target.name, eval_expr(stmt.expr, env))
+            elif isinstance(target, ast.ArrayAccess):
+                arr = env.get(target.array)
+                index = eval_expr(target.index, env)
+                arr[index] = eval_expr(stmt.expr, env)
+            elif isinstance(target, ast.FieldAccess):
+                obj = env.get(target.var)
+                obj[target.field] = eval_expr(stmt.expr, env)
+        elif isinstance(stmt, ast.If):
+            if eval_expr(stmt.condition, env):
+                eval_block(stmt.then_block, env)
+            elif stmt.else_block:
+                eval_block(stmt.else_block, env)
+        elif isinstance(stmt, ast.While):
+            while eval_expr(stmt.condition, env):
+                eval_block(stmt.body, env)
+        elif isinstance(stmt, ast.FuncCallStmt):
+            eval_func_call(stmt.call, env)
+        elif isinstance(stmt, ast.InputStmt):
+            for name in stmt.targets:
+                env.vars[name] = int(input(f"{name} = "))
+        elif isinstance(stmt, ast.OutputStmt):
+            values = [eval_expr(e, env) for e in stmt.exprs]
+            print(*values)
+        else:
+            raise NotImplementedError(type(stmt))
+
+    def eval_expr(expr: ast.Expr, env: Environment):
+        if isinstance(expr, ast.Number):
+            return expr.value
+        elif isinstance(expr, ast.Var):
+            return env.get(expr.name)
+        elif isinstance(expr, ast.ArrayAccess):
+            arr = env.get(expr.array)
+            idx = eval_expr(expr.index, env)
+            return arr[idx]
+        elif isinstance(expr, ast.FieldAccess):
+            obj = env.get(expr.var)
+            return obj[expr.field]
+        elif isinstance(expr, ast.BinaryOp):
+            left = eval_expr(expr.left, env)
+            right = eval_expr(expr.right, env)
+            if expr.op == '+':
+                return left + right
+            if expr.op == '-':
+                return left - right
+            if expr.op == '*':
+                return left * right
+            if expr.op == '/':
+                return left // right
+            if expr.op == '==':
+                return left == right
+            if expr.op == '!=':
+                return left != right
+            if expr.op == '<':
+                return left < right
+            if expr.op == '<=':
+                return left <= right
+            if expr.op == '>':
+                return left > right
+            if expr.op == '>=':
+                return left >= right
+            raise ValueError(expr.op)
+        elif isinstance(expr, ast.UnaryOp):
+            val = eval_expr(expr.operand, env)
+            if expr.op == '-':
+                return -val
+            raise ValueError(expr.op)
+        elif isinstance(expr, ast.FuncCall):
+            return eval_func_call(expr, env)
+        else:
+            raise NotImplementedError(type(expr))
+
+    def eval_func_call(call: ast.FuncCall, env: Environment):
+        if call.name == 'print':
+            vals = [eval_expr(a, env) for a in call.args]
+            print(*vals)
+            return None
+        if call.name not in functions:
+            raise NameError(f"Undefined function {call.name}")
+        func = functions[call.name]
+        args = [eval_expr(a, env) for a in call.args]
+        return call_func(func, args)
+
+    eval_block(prog.main, global_env)
+

--- a/l25/lexer.py
+++ b/l25/lexer.py
@@ -1,0 +1,85 @@
+import ply.lex as lex
+
+# Reserved keywords for L25 language
+reserved = {
+    'program': 'PROGRAM',
+    'func': 'FUNC',
+    'main': 'MAIN',
+    'let': 'LET',
+    'return': 'RETURN',
+    'if': 'IF',
+    'else': 'ELSE',
+    'while': 'WHILE',
+    'input': 'INPUT',
+    'output': 'OUTPUT',
+    'struct': 'STRUCT',
+}
+
+tokens = [
+    'IDENT', 'NUMBER',
+    'PLUS', 'MINUS', 'TIMES', 'DIVIDE',
+    'EQUALS',
+    'EQ', 'NE', 'LT', 'LE', 'GT', 'GE',
+    'LPAREN', 'RPAREN',
+    'LBRACE', 'RBRACE',
+    'LBRACKET', 'RBRACKET',
+    'COMMA', 'SEMICOLON',
+    'DOT',
+] + list(reserved.values())
+
+# Regular expressions for simple tokens
+
+t_PLUS = r'\+'
+t_MINUS = r'-'
+t_TIMES = r'\*'
+t_DIVIDE = r'/'
+t_EQUALS = r'='
+
+t_EQ = r'=='
+t_NE = r'!='
+t_LE = r'<='
+t_LT = r'<'
+t_GE = r'>='
+t_GT = r'>'
+
+
+t_LPAREN = r'\('
+t_RPAREN = r'\)'
+
+t_LBRACE = r'\{'
+t_RBRACE = r'\}'
+
+t_LBRACKET = r'\['
+t_RBRACKET = r'\]'
+
+t_COMMA = r','
+t_SEMICOLON = r';'
+t_DOT = r'\.'
+
+t_ignore = ' \t'
+
+
+def t_IDENT(t):
+    r'[A-Za-z_][A-Za-z0-9_]*'
+    t.type = reserved.get(t.value, 'IDENT')
+    return t
+
+
+def t_NUMBER(t):
+    r'\d+'
+    t.value = int(t.value)
+    return t
+
+
+def t_newline(t):
+    r'\n+'
+    t.lexer.lineno += len(t.value)
+
+
+def t_error(t):
+    raise SyntaxError(f"Illegal character {t.value[0]!r} at line {t.lineno}")
+
+
+def build_lexer(**kwargs):
+    return lex.lex(**kwargs)
+

--- a/l25/main.py
+++ b/l25/main.py
@@ -1,0 +1,17 @@
+from .parser import parse
+from .interpreter import eval_program
+import sys
+
+
+def main(path: str):
+    with open(path, 'r') as f:
+        source = f.read()
+    program = parse(source)
+    eval_program(program)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python -m l25.main <source.l25>')
+    else:
+        main(sys.argv[1])

--- a/l25/parser.py
+++ b/l25/parser.py
@@ -1,0 +1,211 @@
+import ply.yacc as yacc
+from .lexer import tokens, build_lexer
+from . import ast_nodes as ast
+
+
+
+
+class Parser:
+    tokens = tokens
+    precedence = (
+        ('left', 'PLUS', 'MINUS'),
+        ('left', 'TIMES', 'DIVIDE'),
+        ('right', 'UMINUS'),
+    )
+
+    def __init__(self):
+        self.lexer = build_lexer()
+        self.parser = yacc.yacc(module=self)
+
+    def parse(self, text):
+        return self.parser.parse(text, lexer=self.lexer)
+
+    # --- Grammar rules ---
+    def p_program(self, p):
+        """program : PROGRAM IDENT LBRACE func_defs MAIN LBRACE stmt_list RBRACE RBRACE"""
+        p[0] = ast.Program(p[2], p[4], ast.Block(p[7]))
+
+    def p_func_defs(self, p):
+        """func_defs : func_defs func_def
+                     | empty"""
+        if len(p) == 3:
+            p[0] = p[1] + [p[2]]
+        else:
+            p[0] = []
+
+    def p_func_def(self, p):
+        """func_def : FUNC IDENT LPAREN param_list RPAREN LBRACE stmt_list RETURN expr SEMICOLON RBRACE"""
+        p[0] = ast.FuncDef(p[2], p[4], ast.Block(p[7]), p[9])
+
+    def p_param_list(self, p):
+        """param_list : IDENT param_list_tail
+                      | empty"""
+        if len(p) == 3:
+            p[0] = [p[1]] + p[2]
+        else:
+            p[0] = []
+
+    def p_param_list_tail(self, p):
+        """param_list_tail : COMMA IDENT param_list_tail
+                           | empty"""
+        if len(p) == 4:
+            p[0] = [p[2]] + p[3]
+        else:
+            p[0] = []
+
+    def p_stmt_list(self, p):
+        """stmt_list : stmt SEMICOLON stmt_list
+                     | stmt SEMICOLON"""
+        if len(p) == 4:
+            p[0] = [p[1]] + p[3]
+        else:
+            p[0] = [p[1]]
+
+    def p_stmt(self, p):
+        """stmt : declare_stmt
+                | assign_stmt
+                | if_stmt
+                | while_stmt
+                | input_stmt
+                | output_stmt
+                | func_call"""
+        p[0] = p[1]
+
+    def p_declare_stmt(self, p):
+        """declare_stmt : LET IDENT
+                        | LET IDENT EQUALS expr"""
+        if len(p) == 3:
+            p[0] = ast.Declare(p[2])
+        else:
+            p[0] = ast.Declare(p[2], p[4])
+
+    def p_assign_stmt(self, p):
+        """assign_stmt : ident_expr EQUALS expr"""
+        p[0] = ast.Assign(p[1], p[3])
+
+    def p_if_stmt(self, p):
+        """if_stmt : IF LPAREN expr RPAREN LBRACE stmt_list RBRACE else_part"""
+        p[0] = ast.If(p[3], ast.Block(p[6]), p[8])
+
+    def p_else_part(self, p):
+        """else_part : ELSE LBRACE stmt_list RBRACE
+                    | empty"""
+        if len(p) == 5:
+            p[0] = ast.Block(p[3])
+        else:
+            p[0] = None
+
+    def p_while_stmt(self, p):
+        """while_stmt : WHILE LPAREN expr RPAREN LBRACE stmt_list RBRACE"""
+        p[0] = ast.While(p[3], ast.Block(p[6]))
+
+    def p_input_stmt(self, p):
+        """input_stmt : INPUT LPAREN ident_list RPAREN"""
+        p[0] = ast.InputStmt(p[3])
+
+    def p_output_stmt(self, p):
+        """output_stmt : OUTPUT LPAREN expr_list RPAREN"""
+        p[0] = ast.OutputStmt(p[3])
+
+    def p_func_call(self, p):
+        """func_call : IDENT LPAREN arg_list RPAREN"""
+        p[0] = ast.FuncCallStmt(ast.FuncCall(p[1], p[3]))
+
+    def p_arg_list(self, p):
+        """arg_list : expr_list
+                    | empty"""
+        p[0] = p[1] if p[1] is not None else []
+
+    def p_ident_list(self, p):
+        """ident_list : IDENT ident_list_tail"""
+        p[0] = [p[1]] + p[2]
+
+    def p_ident_list_tail(self, p):
+        """ident_list_tail : COMMA IDENT ident_list_tail
+                           | empty"""
+        if len(p) == 4:
+            p[0] = [p[2]] + p[3]
+        else:
+            p[0] = []
+
+    def p_expr_list(self, p):
+        """expr_list : expr expr_list_tail"""
+        p[0] = [p[1]] + p[2]
+
+    def p_expr_list_tail(self, p):
+        """expr_list_tail : COMMA expr expr_list_tail
+                          | empty"""
+        if len(p) == 4:
+            p[0] = [p[2]] + p[3]
+        else:
+            p[0] = []
+
+    def p_expr(self, p):
+        """expr : expr PLUS term
+                | expr MINUS term"""
+        p[0] = ast.BinaryOp(p[2], p[1], p[3])
+
+    def p_expr_term(self, p):
+        """expr : term"""
+        p[0] = p[1]
+
+    def p_term(self, p):
+        """term : term TIMES factor
+                 | term DIVIDE factor"""
+        p[0] = ast.BinaryOp(p[2], p[1], p[3])
+
+    def p_term_factor(self, p):
+        """term : factor"""
+        p[0] = p[1]
+
+    def p_factor_number(self, p):
+        """factor : NUMBER"""
+        p[0] = ast.Number(p[1])
+
+    def p_factor_ident(self, p):
+        """factor : ident_expr"""
+        p[0] = p[1]
+
+    def p_factor_group(self, p):
+        """factor : LPAREN expr RPAREN"""
+        p[0] = p[2]
+
+    def p_ident_expr(self, p):
+        """ident_expr : IDENT
+                      | IDENT LBRACKET expr RBRACKET
+                      | IDENT DOT IDENT
+                      | func_call_expr"""
+        if len(p) == 2:
+            if isinstance(p[1], ast.FuncCall):
+                p[0] = p[1]
+            else:
+                p[0] = ast.Var(p[1])
+        elif len(p) == 5:
+            p[0] = ast.ArrayAccess(p[1], p[3])
+        elif len(p) == 4 and p[2] == '.':
+            p[0] = ast.FieldAccess(p[1], p[3])
+        else:
+            p[0] = p[1]
+
+    def p_func_call_expr(self, p):
+        """func_call_expr : IDENT LPAREN arg_list RPAREN"""
+        p[0] = ast.FuncCall(p[1], p[3])
+
+    def p_expr_unary(self, p):
+        """factor : MINUS factor %prec UMINUS"""
+        p[0] = ast.UnaryOp('-', p[2])
+
+    def p_empty(self, p):
+        'empty :'
+        p[0] = None
+
+    def p_error(self, p):
+        if p:
+            raise SyntaxError(f"Syntax error at '{p.value}' on line {p.lineno}")
+        else:
+            raise SyntaxError('Unexpected EOF')
+
+
+def parse(text: str) -> ast.Program:
+    return Parser().parse(text)
+

--- a/l25/tests/test_sample.py
+++ b/l25/tests/test_sample.py
@@ -1,0 +1,22 @@
+from l25.main import main
+import tempfile
+import textwrap
+
+source = textwrap.dedent('''
+program demo {
+func add(a, b) {
+let c = a + b;
+return c;
+}
+main {
+let x = add(1,2);
+output(x);
+}
+}
+''')
+
+with tempfile.NamedTemporaryFile('w+', suffix='.l25', delete=False) as f:
+    f.write(source)
+    fname = f.name
+
+main(fname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tensorboardX==2.0
 threadpoolctl==2.1.0
 torch==1.4.0+cu100
 torchvision==0.5.0+cu100
+ply==3.11


### PR DESCRIPTION
## Summary
- add an L25 interpreter implementation under `l25/`
- integrate tokens, parser, AST and interpreter
- provide minimal smoke test
- update requirements and gitignore

## Testing
- `python l25/tests/test_sample.py`
- `python test.py`
- `python validation.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68444dbb274c8331993beba8da7172fa