### PR TITLE
Implement map and set containers

### DIFF
--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -3,9 +3,9 @@
 This directory contains a simple compiler and interpreter for the L25 language
 written in Python. In addition to the base features, it implements support for
 one‑dimensional static arrays, simple structures (structs), basic pointer
-operations (`&` address-of and `*` dereference), and simple `map`/`set`
-containers with helper functions for insertion, deletion, lookup and
-iteration.
+operations (`&` address-of and `*` dereference), simple `map`/`set` containers
+with helper functions for insertion, deletion, lookup and iteration, and a
+`do...until` loop construct.
 
 ## Usage
 
@@ -74,3 +74,4 @@ The interpreter provides a few built-in functions for manipulating `map` and
 - `map_set.l25`: Demonstrates map and set operations using all helper functions.
 - `complex_edge.l25`: Exercises struct arrays, pointer manipulation and
   boundary behaviors of map/set helpers.
+- `do_until.l25`: Shows the new `do...until` looping construct.

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -57,4 +57,4 @@ The interpreter provides a few built-in functions for manipulating `map` and
 - `sum.l25`: Sum numbers from 1 to `n`.
 - `array_struct.l25`: Demonstrates arrays and structs.
 - `pointer.l25`: Demonstrates basic pointer usage.
-- `map_set.l25`: Demonstrates map and set operations.
+- `map_set.l25`: Demonstrates map and set operations using all helper functions.

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -19,8 +19,9 @@ For a graphical interface, run:
 python -m l25_compiler.gui
 ```
 
-The GUI shows tokens, AST, IR, TAC and runtime output in separate read-only
-panes labeled in Chinese.
+The GUI presents a notebook with tabs labeled in Chinese for tokens, AST, IR
+and TAC. Selecting a tab shows the corresponding intermediate output. A second
+pane of equal size displays the program's runtime output.
 
 By default the program is interpreted directly. Additional options allow
 inspection of intermediate stages:

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -13,6 +13,12 @@ iteration.
 python -m l25_compiler.main [options] <source.l25>
 ```
 
+For a graphical interface, run:
+
+```
+python -m l25_compiler.gui
+```
+
 By default the program is interpreted directly. Additional options allow
 inspection of intermediate stages:
 

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -1,7 +1,8 @@
 # L25 Compiler (Basic)
 
-This directory contains a simple compiler and interpreter for the L25 language
-written in Python. In addition to the base features, it implements support for
+This directory contains a simple compiler for the L25 language written in
+Python. Source files are translated into a stack-based pcode which is executed
+by a small virtual machine. In addition to the base features, it implements support for
 one‑dimensional static arrays, simple structures (structs), basic pointer
 operations (`&` address-of and `*` dereference), simple `map`/`set` containers
 with helper functions for insertion, deletion, lookup and iteration, and a
@@ -26,7 +27,7 @@ loaded its contents appear in a read-only box above the input area. If the
 program requires input but none is provided, the GUI warns the user instead of
 failing.
 
-By default the program is interpreted directly. Additional options allow
+By default the compiled pcode is executed on the virtual machine. Additional options allow
 inspection of intermediate stages:
 
 - `--tokens` &ndash; output the token stream
@@ -51,7 +52,7 @@ python -m l25_compiler.main examples/factorial.l25
 
 ### Map/Set Helpers
 
-The interpreter provides a few built-in functions for manipulating `map` and
+The virtual machine provides a few built-in functions for manipulating `map` and
 `set` values:
 
 - `map_insert(m, key, value)` – add or update an entry

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -23,9 +23,10 @@ python -m l25_compiler.gui
 The GUI presents a notebook with tabs labeled in Chinese for tokens, AST, IR,
 TAC and PCODE. Selecting a tab shows the corresponding intermediate output. A second
 pane of equal size displays the program's runtime output. When a source file is
-loaded its contents appear in a read-only box above the input area. If the
-program requires input but none is provided, the GUI warns the user instead of
-failing.
+loaded its contents appear in an **editable** box above the input area so you can
+modify the code and recompile at any time. If the program requires input but none
+is provided, the GUI issues a warning. Should a runtime error occur, any output
+produced before the error is still shown.
 
 By default the compiled pcode is executed on the virtual machine. Additional options allow
 inspection of intermediate stages:

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -21,7 +21,10 @@ python -m l25_compiler.gui
 
 The GUI presents a notebook with tabs labeled in Chinese for tokens, AST, IR
 and TAC. Selecting a tab shows the corresponding intermediate output. A second
-pane of equal size displays the program's runtime output.
+pane of equal size displays the program's runtime output. When a source file is
+loaded its contents appear in a read-only box above the input area. If the
+program requires input but none is provided, the GUI warns the user instead of
+failing.
 
 By default the program is interpreted directly. Additional options allow
 inspection of intermediate stages:

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -72,3 +72,5 @@ The interpreter provides a few built-in functions for manipulating `map` and
 - `array_struct.l25`: Demonstrates arrays and structs.
 - `pointer.l25`: Demonstrates basic pointer usage.
 - `map_set.l25`: Demonstrates map and set operations using all helper functions.
+- `complex_edge.l25`: Exercises struct arrays, pointer manipulation and
+  boundary behaviors of map/set helpers.

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -19,6 +19,9 @@ For a graphical interface, run:
 python -m l25_compiler.gui
 ```
 
+The GUI shows tokens, AST, IR, TAC and runtime output in separate read-only
+panes labeled in Chinese.
+
 By default the program is interpreted directly. Additional options allow
 inspection of intermediate stages:
 

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -1,0 +1,60 @@
+# L25 Compiler (Basic)
+
+This directory contains a simple compiler and interpreter for the L25 language
+written in Python. In addition to the base features, it implements support for
+one‑dimensional static arrays, simple structures (structs), basic pointer
+operations (`&` address-of and `*` dereference), and simple `map`/`set`
+containers with helper functions for insertion, deletion, lookup and
+iteration.
+
+## Usage
+
+```
+python -m l25_compiler.main [options] <source.l25>
+```
+
+By default the program is interpreted directly. Additional options allow
+inspection of intermediate stages:
+
+- `--tokens` &ndash; output the token stream
+- `--ast` &ndash; dump the parsed abstract syntax tree
+- `--ir` &ndash; print a simplified intermediate representation
+- `--tac` &ndash; emit linear three-address code
+- `--no-run` &ndash; skip execution after generating the chosen outputs
+
+## Testing
+
+Three example programs are provided in the `examples` directory. You can run
+one normally or request intermediate output:
+
+```
+python -m l25_compiler.main examples/factorial.l25
+
+# show tokens and IR only
+    python -m l25_compiler.main --tokens --ir --tac --no-run \
+    examples/factorial.l25
+```
+
+### Map/Set Helpers
+
+The interpreter provides a few built-in functions for manipulating `map` and
+`set` values:
+
+- `map_insert(m, key, value)` – add or update an entry
+- `map_delete(m, key)` – remove an entry
+- `map_get(m, key)` – fetch a value (returns `0` if absent)
+- `map_has(m, key)` – test for membership
+- `map_keys(m)` – return an array of keys
+- `set_add(s, value)` – insert a value
+- `set_remove(s, value)` – delete a value
+- `set_contains(s, value)` – check for membership
+- `set_items(s)` – return an array of elements
+
+## Example Programs
+
+- `factorial.l25`: Compute factorial of an integer.
+- `fibonacci.l25`: Output Fibonacci sequence up to `n`.
+- `sum.l25`: Sum numbers from 1 to `n`.
+- `array_struct.l25`: Demonstrates arrays and structs.
+- `pointer.l25`: Demonstrates basic pointer usage.
+- `map_set.l25`: Demonstrates map and set operations.

--- a/l25_compiler/README.md
+++ b/l25_compiler/README.md
@@ -19,8 +19,8 @@ For a graphical interface, run:
 python -m l25_compiler.gui
 ```
 
-The GUI presents a notebook with tabs labeled in Chinese for tokens, AST, IR
-and TAC. Selecting a tab shows the corresponding intermediate output. A second
+The GUI presents a notebook with tabs labeled in Chinese for tokens, AST, IR,
+TAC and PCODE. Selecting a tab shows the corresponding intermediate output. A second
 pane of equal size displays the program's runtime output. When a source file is
 loaded its contents appear in a read-only box above the input area. If the
 program requires input but none is provided, the GUI warns the user instead of
@@ -33,6 +33,7 @@ inspection of intermediate stages:
 - `--ast` &ndash; dump the parsed abstract syntax tree
 - `--ir` &ndash; print a simplified intermediate representation
 - `--tac` &ndash; emit linear three-address code
+- `--pcode` &ndash; emit stack-based pcode instructions
 - `--no-run` &ndash; skip execution after generating the chosen outputs
 
 ## Testing
@@ -43,8 +44,8 @@ one normally or request intermediate output:
 ```
 python -m l25_compiler.main examples/factorial.l25
 
-# show tokens and IR only
-    python -m l25_compiler.main --tokens --ir --tac --no-run \
+# show tokens and intermediate code only
+    python -m l25_compiler.main --tokens --ir --tac --pcode --no-run \
     examples/factorial.l25
 ```
 

--- a/l25_compiler/__init__.py
+++ b/l25_compiler/__init__.py
@@ -6,6 +6,7 @@ from .interpreter import Interpreter
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
 from .utils import dump_ast
+from .gui import run_compiler, L25GUI
 
 __all__ = [
     "tokenize",
@@ -14,4 +15,6 @@ __all__ = [
     "IRGenerator",
     "ThreeAddressGenerator",
     "dump_ast",
+    "run_compiler",
+    "L25GUI",
 ]

--- a/l25_compiler/__init__.py
+++ b/l25_compiler/__init__.py
@@ -1,0 +1,17 @@
+"""L25 compiler package."""
+
+from .lexer import tokenize
+from .parser import Parser
+from .interpreter import Interpreter
+from .ir import IRGenerator
+from .tac import ThreeAddressGenerator
+from .utils import dump_ast
+
+__all__ = [
+    "tokenize",
+    "Parser",
+    "Interpreter",
+    "IRGenerator",
+    "ThreeAddressGenerator",
+    "dump_ast",
+]

--- a/l25_compiler/__init__.py
+++ b/l25_compiler/__init__.py
@@ -5,6 +5,7 @@ from .parser import Parser
 from .interpreter import Interpreter
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
+from .pcode import PCodeGenerator
 from .utils import dump_ast
 from .gui import run_compiler, L25GUI
 
@@ -14,6 +15,7 @@ __all__ = [
     "Interpreter",
     "IRGenerator",
     "ThreeAddressGenerator",
+    "PCodeGenerator",
     "dump_ast",
     "run_compiler",
     "L25GUI",

--- a/l25_compiler/__init__.py
+++ b/l25_compiler/__init__.py
@@ -2,7 +2,7 @@
 
 from .lexer import tokenize
 from .parser import Parser
-from .interpreter import Interpreter
+from .pcode_vm import PCodeVM
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
 from .pcode import PCodeGenerator
@@ -12,7 +12,7 @@ from .gui import run_compiler, L25GUI
 __all__ = [
     "tokenize",
     "Parser",
-    "Interpreter",
+    "PCodeVM",
     "IRGenerator",
     "ThreeAddressGenerator",
     "PCodeGenerator",

--- a/l25_compiler/ast_nodes.py
+++ b/l25_compiler/ast_nodes.py
@@ -40,6 +40,11 @@ class While(Node):
         self.cond = cond
         self.body = body
 
+class DoUntil(Node):
+    def __init__(self, cond, body):
+        self.cond = cond
+        self.body = body
+
 class Input(Node):
     def __init__(self, names):
         self.names = names

--- a/l25_compiler/ast_nodes.py
+++ b/l25_compiler/ast_nodes.py
@@ -1,0 +1,103 @@
+class Node:
+    pass
+
+class Program(Node):
+    def __init__(self, name, funcs, main):
+        self.name = name
+        self.funcs = funcs
+        self.main = main
+
+class FuncDef(Node):
+    def __init__(self, name, params, body, ret):
+        self.name = name
+        self.params = params
+        self.body = body
+        self.ret = ret
+
+class StmtList(Node):
+    def __init__(self, stmts):
+        self.stmts = stmts
+
+class Declare(Node):
+    def __init__(self, name, expr=None, size=None):
+        self.name = name
+        self.expr = expr
+        self.size = size
+
+class Assign(Node):
+    def __init__(self, target, expr):
+        self.target = target
+        self.expr = expr
+
+class If(Node):
+    def __init__(self, cond, then, else_=None):
+        self.cond = cond
+        self.then = then
+        self.else_ = else_
+
+class While(Node):
+    def __init__(self, cond, body):
+        self.cond = cond
+        self.body = body
+
+class Input(Node):
+    def __init__(self, names):
+        self.names = names
+
+class Output(Node):
+    def __init__(self, exprs):
+        self.exprs = exprs
+
+class FuncCall(Node):
+    def __init__(self, name, args):
+        self.name = name
+        self.args = args
+
+class Return(Node):
+    def __init__(self, expr):
+        self.expr = expr
+
+class BinaryOp(Node):
+    def __init__(self, op, left, right):
+        self.op = op
+        self.left = left
+        self.right = right
+
+class UnaryOp(Node):
+    def __init__(self, op, operand):
+        self.op = op
+        self.operand = operand
+
+class Number(Node):
+    def __init__(self, value):
+        self.value = value
+
+class Identifier(Node):
+    def __init__(self, name):
+        self.name = name
+
+class ArrayAccess(Node):
+    def __init__(self, array, index):
+        self.array = array
+        self.index = index
+
+class FieldAccess(Node):
+    def __init__(self, obj, field):
+        self.obj = obj
+        self.field = field
+
+class ArrayLiteral(Node):
+    def __init__(self, elements):
+        self.elements = elements
+
+class StructLiteral(Node):
+    def __init__(self, fields):
+        self.fields = fields
+
+class MapLiteral(Node):
+    def __init__(self, pairs):
+        self.pairs = pairs  # list of (key, value)
+
+class SetLiteral(Node):
+    def __init__(self, elements):
+        self.elements = elements

--- a/l25_compiler/examples/array_struct.l25
+++ b/l25_compiler/examples/array_struct.l25
@@ -1,0 +1,11 @@
+program demo {
+main {
+    let arr[3];
+    arr[0] = 1;
+    arr[1] = 2;
+    arr[2] = arr[0] + arr[1];
+    let p = struct { x = arr[2]; y = 4; };
+    p.y = p.y + arr[0];
+    output(p.x, p.y);
+}
+}

--- a/l25_compiler/examples/complex_edge.l25
+++ b/l25_compiler/examples/complex_edge.l25
@@ -1,0 +1,37 @@
+program complex {
+func inc(p) {
+    *p = *p + 1;
+    return 0;
+}
+main {
+    let arr[2];
+    arr[0] = struct {x = 1; y = 2;};
+    arr[1] = struct {x = 3; y = 4;};
+    inc(&arr[0].x);
+    inc(&arr[1].y);
+    output(arr[0].x, arr[1].y);
+
+    let m = map {1: 10;};
+    output(map_get(m, 2));
+    map_delete(m, 2);
+    map_insert(m, 1, 11);
+    map_insert(m, 2, 22);
+    let ks = map_keys(m);
+    output(ks[0], ks[1]);
+    output(m[ks[0]], m[ks[1]]);
+
+    let s = set {1;};
+    set_remove(s, 2);
+    set_add(s, 2);
+    set_add(s, 1);
+    let its = set_items(s);
+    output(its[0], its[1]);
+    output(set_contains(s, 1), set_contains(s, 3));
+
+    let i = 0;
+    while (i < 0) {
+        output(i);
+        i = i + 1;
+    };
+}
+}

--- a/l25_compiler/examples/do_until.l25
+++ b/l25_compiler/examples/do_until.l25
@@ -1,0 +1,11 @@
+program demo {
+main {
+    let i = 0;
+    let sum = 0;
+    do {
+        i = i + 1;
+        sum = sum + i;
+    } until (i >= 5);
+    output(sum);
+}
+}

--- a/l25_compiler/examples/factorial.l25
+++ b/l25_compiler/examples/factorial.l25
@@ -1,0 +1,11 @@
+program fact {
+main {
+    input(n);
+    let res = 1;
+    while (n > 1) {
+        res = res * n;
+        n = n - 1;
+    };
+    output(res);
+}
+}

--- a/l25_compiler/examples/fibonacci.l25
+++ b/l25_compiler/examples/fibonacci.l25
@@ -1,0 +1,19 @@
+program fib {
+main {
+    input(n);
+    let a = 0;
+    let b = 1;
+    output(a);
+    if (n > 0) {
+        output(b);
+        let i = 2;
+        while (i <= n) {
+            let c = a + b;
+            output(c);
+            a = b;
+            b = c;
+            i = i + 1;
+        };
+    };
+}
+}

--- a/l25_compiler/examples/map_set.l25
+++ b/l25_compiler/examples/map_set.l25
@@ -1,0 +1,15 @@
+program demo {
+main {
+    let m = map { 1: 10; 2: 20; };
+    let s = set { 3; };
+    map_insert(m, 3, 30);
+    set_add(s, 4);
+    output(m[1], map_get(m, 3), set_contains(s, 4));
+    let keys = map_keys(m);
+    let i = 0;
+    while (i < 3) {
+        output(keys[i], m[keys[i]]);
+        i = i + 1;
+    };
+}
+}

--- a/l25_compiler/examples/map_set.l25
+++ b/l25_compiler/examples/map_set.l25
@@ -2,14 +2,28 @@ program demo {
 main {
     let m = map { 1: 10; 2: 20; };
     let s = set { 3; };
+
     map_insert(m, 3, 30);
-    set_add(s, 4);
-    output(m[1], map_get(m, 3), set_contains(s, 4));
+    map_delete(m, 1);
+    output(map_has(m, 1), map_has(m, 3));
+    output(map_get(m, 2), map_get(m, 3));
+
     let keys = map_keys(m);
     let i = 0;
-    while (i < 3) {
+    while (i < 2) {
         output(keys[i], m[keys[i]]);
         i = i + 1;
+    };
+
+    set_add(s, 4);
+    set_remove(s, 3);
+    output(set_contains(s, 3), set_contains(s, 4));
+
+    let items = set_items(s);
+    let j = 0;
+    while (j < 1) {
+        output(items[j]);
+        j = j + 1;
     };
 }
 }

--- a/l25_compiler/examples/pointer.l25
+++ b/l25_compiler/examples/pointer.l25
@@ -1,0 +1,16 @@
+program ptr {
+func swap(a, b) {
+    let temp = *a;
+    *a = *b;
+    *b = temp;
+    return 0;
+}
+main {
+    let x = 3;
+    let y = 5;
+    let px = &x;
+    let py = &y;
+    swap(px, py);
+    output(x, y);
+}
+}

--- a/l25_compiler/examples/sum.l25
+++ b/l25_compiler/examples/sum.l25
@@ -1,0 +1,12 @@
+program sum {
+main {
+    input(n);
+    let s = 0;
+    let i = 1;
+    while (i <= n) {
+        s = s + i;
+        i = i + 1;
+    };
+    output(s);
+}
+}

--- a/l25_compiler/gui.py
+++ b/l25_compiler/gui.py
@@ -7,10 +7,11 @@ from .parser import Parser
 from .utils import dump_ast
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
+from .pcode import PCodeGenerator
 from .interpreter import Interpreter
 
 
-def run_compiler(path, show_tokens=False, show_ast=False, show_ir=False, show_tac=False, run_program=True, input_text=""):
+def run_compiler(path, show_tokens=False, show_ast=False, show_ir=False, show_tac=False, show_pcode=False, run_program=True, input_text=""):
     with open(path) as f:
         code = f.read()
 
@@ -23,6 +24,7 @@ def run_compiler(path, show_tokens=False, show_ast=False, show_ir=False, show_ta
 
     ir_str = "\n".join(IRGenerator().generate(ast)) if show_ir else ""
     tac_str = "\n".join(ThreeAddressGenerator().generate(ast)) if show_tac else ""
+    pcode_str = "\n".join(PCodeGenerator().generate(ast)) if show_pcode else ""
 
     program_output = ""
     if run_program:
@@ -50,6 +52,7 @@ def run_compiler(path, show_tokens=False, show_ast=False, show_ir=False, show_ta
         "ast": ast_str,
         "ir": ir_str,
         "tac": tac_str,
+        "pcode": pcode_str,
         "output": program_output,
     }
 
@@ -72,11 +75,13 @@ class L25GUI:
         self.ast_var = tk.IntVar()
         self.ir_var = tk.IntVar()
         self.tac_var = tk.IntVar()
+        self.pcode_var = tk.IntVar()
         self.run_var = tk.IntVar(value=1)
         tk.Checkbutton(opts, text="词法", variable=self.token_var).pack(side=tk.LEFT)
         tk.Checkbutton(opts, text="AST", variable=self.ast_var).pack(side=tk.LEFT)
         tk.Checkbutton(opts, text="IR", variable=self.ir_var).pack(side=tk.LEFT)
         tk.Checkbutton(opts, text="TAC", variable=self.tac_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="PCODE", variable=self.pcode_var).pack(side=tk.LEFT)
         tk.Checkbutton(opts, text="运行", variable=self.run_var).pack(side=tk.LEFT)
 
         self.code_display = scrolledtext.ScrolledText(root, height=10, state=tk.DISABLED)
@@ -100,6 +105,7 @@ class L25GUI:
         self.ast_output = self._create_tab(notebook, "AST")
         self.ir_output = self._create_tab(notebook, "IR")
         self.tac_output = self._create_tab(notebook, "TAC")
+        self.pcode_output = self._create_tab(notebook, "PCODE")
 
         run_frame = tk.Frame(output_frame)
         run_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(5, 0))
@@ -191,6 +197,7 @@ class L25GUI:
                 show_ast=bool(self.ast_var.get()),
                 show_ir=bool(self.ir_var.get()),
                 show_tac=bool(self.tac_var.get()),
+                show_pcode=bool(self.pcode_var.get()),
                 run_program=bool(self.run_var.get()),
                 input_text=input_text,
             )
@@ -205,6 +212,7 @@ class L25GUI:
         self._set_text(self.ast_output, result["ast"])
         self._set_text(self.ir_output, result["ir"])
         self._set_text(self.tac_output, result["tac"])
+        self._set_text(self.pcode_output, result["pcode"])
         self._set_text(self.run_output, result["output"])
 
 

--- a/l25_compiler/gui.py
+++ b/l25_compiler/gui.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import filedialog, scrolledtext
+from tkinter import filedialog, scrolledtext, ttk
 import io
 from contextlib import redirect_stdout
 from .lexer import tokenize
@@ -90,16 +90,23 @@ class L25GUI:
         output_frame = tk.Frame(root)
         output_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
-        self.token_output = self._create_output_box(output_frame, "词法")
-        self.ast_output = self._create_output_box(output_frame, "AST")
-        self.ir_output = self._create_output_box(output_frame, "IR")
-        self.tac_output = self._create_output_box(output_frame, "TAC")
-        self.run_output = self._create_output_box(output_frame, "运行结果")
+        notebook = ttk.Notebook(output_frame)
+        notebook.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-    def _create_output_box(self, parent, title):
-        frame = tk.Frame(parent)
-        frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=2)
-        tk.Label(frame, text=title).pack()
+        self.token_output = self._create_tab(notebook, "词法")
+        self.ast_output = self._create_tab(notebook, "AST")
+        self.ir_output = self._create_tab(notebook, "IR")
+        self.tac_output = self._create_tab(notebook, "TAC")
+
+        run_frame = tk.Frame(output_frame)
+        run_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=(5, 0))
+        tk.Label(run_frame, text="运行结果").pack()
+        self.run_output = scrolledtext.ScrolledText(run_frame, height=15, state=tk.DISABLED)
+        self.run_output.pack(fill=tk.BOTH, expand=True)
+
+    def _create_tab(self, notebook, title):
+        frame = tk.Frame(notebook)
+        notebook.add(frame, text=title)
         box = scrolledtext.ScrolledText(frame, height=15, state=tk.DISABLED)
         box.pack(fill=tk.BOTH, expand=True)
         return box

--- a/l25_compiler/gui.py
+++ b/l25_compiler/gui.py
@@ -1,0 +1,122 @@
+import tkinter as tk
+from tkinter import filedialog, scrolledtext
+import io
+from contextlib import redirect_stdout
+from .lexer import tokenize
+from .parser import Parser
+from .utils import dump_ast
+from .ir import IRGenerator
+from .tac import ThreeAddressGenerator
+from .interpreter import Interpreter
+
+
+def run_compiler(path, show_tokens=False, show_ast=False, show_ir=False, show_tac=False, run_program=True, input_text=""):
+    with open(path) as f:
+        code = f.read()
+
+    output_lines = []
+    tokens = list(tokenize(code))
+    if show_tokens:
+        output_lines += [str(t) for t in tokens]
+
+    parser = Parser(tokens)
+    ast = parser.parse()
+    if show_ast:
+        output_lines += dump_ast(ast)
+
+    ir_lines = IRGenerator().generate(ast)
+    tac_lines = ThreeAddressGenerator().generate(ast)
+    if show_ir:
+        output_lines += ir_lines
+    if show_tac:
+        output_lines += tac_lines
+
+    if run_program:
+        inputs = iter(input_text.splitlines())
+
+        def fake_input(prompt=""):
+            try:
+                return next(inputs)
+            except StopIteration:
+                return ""
+
+        buf = io.StringIO()
+        import builtins
+        real_input = builtins.input
+        builtins.input = fake_input
+        try:
+            with redirect_stdout(buf):
+                Interpreter(ast).run()
+        finally:
+            builtins.input = real_input
+        output_lines.append(buf.getvalue().strip())
+
+    return "\n".join(output_lines)
+
+
+class L25GUI:
+    def __init__(self, root):
+        self.root = root
+        root.title("L25 Compiler")
+
+        file_frame = tk.Frame(root)
+        file_frame.pack(fill=tk.X, padx=5, pady=5)
+        tk.Label(file_frame, text="Source file:").pack(side=tk.LEFT)
+        self.path_var = tk.StringVar()
+        tk.Entry(file_frame, textvariable=self.path_var, width=40).pack(side=tk.LEFT, expand=True, fill=tk.X)
+        tk.Button(file_frame, text="Browse", command=self.browse).pack(side=tk.LEFT, padx=5)
+
+        opts = tk.Frame(root)
+        opts.pack(fill=tk.X, padx=5)
+        self.token_var = tk.IntVar()
+        self.ast_var = tk.IntVar()
+        self.ir_var = tk.IntVar()
+        self.tac_var = tk.IntVar()
+        self.run_var = tk.IntVar(value=1)
+        tk.Checkbutton(opts, text="Tokens", variable=self.token_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="AST", variable=self.ast_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="IR", variable=self.ir_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="TAC", variable=self.tac_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="Run", variable=self.run_var).pack(side=tk.LEFT)
+
+        input_frame = tk.Frame(root)
+        input_frame.pack(fill=tk.BOTH, padx=5, pady=5)
+        tk.Label(input_frame, text="Program Input (one value per line):").pack(anchor=tk.W)
+        self.input_text = tk.Text(input_frame, height=4)
+        self.input_text.pack(fill=tk.BOTH, expand=True)
+
+        tk.Button(root, text="Compile", command=self.compile).pack(pady=5)
+
+        self.output = scrolledtext.ScrolledText(root, height=20)
+        self.output.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+    def browse(self):
+        path = filedialog.askopenfilename(filetypes=[("L25 files", "*.l25"), ("All files", "*")])
+        if path:
+            self.path_var.set(path)
+
+    def compile(self):
+        path = self.path_var.get()
+        if not path:
+            return
+        result = run_compiler(
+            path,
+            show_tokens=bool(self.token_var.get()),
+            show_ast=bool(self.ast_var.get()),
+            show_ir=bool(self.ir_var.get()),
+            show_tac=bool(self.tac_var.get()),
+            run_program=bool(self.run_var.get()),
+            input_text=self.input_text.get("1.0", tk.END),
+        )
+        self.output.delete("1.0", tk.END)
+        self.output.insert(tk.END, result)
+
+
+def main():
+    root = tk.Tk()
+    L25GUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/l25_compiler/interpreter.py
+++ b/l25_compiler/interpreter.py
@@ -1,0 +1,239 @@
+from .ast_nodes import *
+
+class Environment:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.vars = {}
+
+    def get(self, name):
+        if name in self.vars:
+            return self.vars[name]
+        if self.parent:
+            return self.parent.get(name)
+        raise NameError(f'Undefined variable {name}')
+
+    def set(self, name, value):
+        if name in self.vars:
+            self.vars[name] = value
+        elif self.parent:
+            self.parent.set(name, value)
+        else:
+            raise NameError(f'Undefined variable {name}')
+
+    def define(self, name, value=0):
+        self.vars[name] = value
+
+    def lookup_env(self, name):
+        if name in self.vars:
+            return self
+        if self.parent:
+            return self.parent.lookup_env(name)
+        raise NameError(f'Undefined variable {name}')
+
+class Pointer:
+    def __init__(self, container, key):
+        self.container = container
+        self.key = key
+
+    def get(self):
+        if isinstance(self.container, Environment):
+            return self.container.vars[self.key]
+        else:
+            return self.container[self.key]
+
+    def set(self, value):
+        if isinstance(self.container, Environment):
+            self.container.vars[self.key] = value
+        else:
+            self.container[self.key] = value
+
+class Interpreter:
+    def __init__(self, ast):
+        self.ast = ast
+        self.functions = {f.name: f for f in ast.funcs}
+
+    def run(self):
+        env = Environment()
+        self.exec_stmt_list(self.ast.main, env)
+
+    def eval_expr(self, node, env):
+        if isinstance(node, Number):
+            return node.value
+        if isinstance(node, Identifier):
+            return env.get(node.name)
+        if isinstance(node, ArrayAccess):
+            arr = self.eval_expr(node.array, env)
+            idx = self.eval_expr(node.index, env)
+            return arr[idx]
+        if isinstance(node, FieldAccess):
+            obj = self.eval_expr(node.obj, env)
+            return obj.get(node.field)
+        if isinstance(node, ArrayLiteral):
+            return [self.eval_expr(e, env) for e in node.elements]
+        if isinstance(node, StructLiteral):
+            return {k: self.eval_expr(v, env) for k, v in node.fields.items()}
+        if isinstance(node, MapLiteral):
+            return {self.eval_expr(k, env): self.eval_expr(v, env) for k, v in node.pairs}
+        if isinstance(node, SetLiteral):
+            return set(self.eval_expr(e, env) for e in node.elements)
+        if isinstance(node, UnaryOp):
+            if node.op == '+':
+                val = self.eval_expr(node.operand, env)
+                return +val
+            if node.op == '-':
+                val = self.eval_expr(node.operand, env)
+                return -val
+            if node.op == '&':
+                return self.make_pointer(node.operand, env)
+            if node.op == '*':
+                ptr = self.eval_expr(node.operand, env)
+                if not isinstance(ptr, Pointer):
+                    raise RuntimeError('Cannot dereference non-pointer')
+                return ptr.get()
+            raise RuntimeError(f'Unknown unary operator {node.op}')
+        if isinstance(node, BinaryOp):
+            left = self.eval_expr(node.left, env)
+            right = self.eval_expr(node.right, env)
+            if node.op == '+':
+                return left + right
+            if node.op == '-':
+                return left - right
+            if node.op == '*':
+                return left * right
+            if node.op == '/':
+                return left // right
+            if node.op == '==':
+                return int(left == right)
+            if node.op == '!=':
+                return int(left != right)
+            if node.op == '<':
+                return int(left < right)
+            if node.op == '<=':
+                return int(left <= right)
+            if node.op == '>':
+                return int(left > right)
+            if node.op == '>=':
+                return int(left >= right)
+            raise RuntimeError(f'Unknown operator {node.op}')
+        if isinstance(node, FuncCall):
+            return self.call_func(node, env)
+        raise RuntimeError('Unknown expression')
+
+    def exec_stmt_list(self, stmt_list, env):
+        for stmt in stmt_list.stmts:
+            self.exec_stmt(stmt, env)
+
+    def exec_stmt(self, stmt, env):
+        if isinstance(stmt, Declare):
+            if stmt.size is not None:
+                size = self.eval_expr(stmt.size, env)
+                env.define(stmt.name, [0] * size)
+            else:
+                value = self.eval_expr(stmt.expr, env) if stmt.expr else 0
+                env.define(stmt.name, value)
+        elif isinstance(stmt, Assign):
+            val = self.eval_expr(stmt.expr, env)
+            target = stmt.target
+            if isinstance(target, Identifier):
+                env.set(target.name, val)
+            elif isinstance(target, ArrayAccess):
+                arr = self.eval_expr(target.array, env)
+                idx = self.eval_expr(target.index, env)
+                arr[idx] = val
+            elif isinstance(target, FieldAccess):
+                obj = self.eval_expr(target.obj, env)
+                obj[target.field] = val
+            elif isinstance(target, UnaryOp) and target.op == '*':
+                ptr = self.eval_expr(target.operand, env)
+                if not isinstance(ptr, Pointer):
+                    raise RuntimeError('Cannot dereference non-pointer')
+                ptr.set(val)
+            else:
+                raise RuntimeError('Invalid assignment target')
+        elif isinstance(stmt, If):
+            cond = self.eval_expr(stmt.cond, env)
+            if cond:
+                self.exec_stmt_list(stmt.then, Environment(env))
+            elif stmt.else_:
+                self.exec_stmt_list(stmt.else_, Environment(env))
+        elif isinstance(stmt, While):
+            while self.eval_expr(stmt.cond, env):
+                self.exec_stmt_list(stmt.body, Environment(env))
+        elif isinstance(stmt, Input):
+            for name in stmt.names:
+                val = int(input(f'{name}: '))
+                env.set(name, val) if name in env.vars else env.define(name, val)
+        elif isinstance(stmt, Output):
+            vals = [self.eval_expr(e, env) for e in stmt.exprs]
+            print(*vals)
+        elif isinstance(stmt, FuncCall):
+            self.call_func(stmt, env)
+        else:
+            raise RuntimeError('Unknown statement')
+
+    def call_func(self, call, env):
+        # Built-in functions for map and set operations
+        name = call.name
+        if name == 'map_insert':
+            m = self.eval_expr(call.args[0], env)
+            k = self.eval_expr(call.args[1], env)
+            v = self.eval_expr(call.args[2], env)
+            m[k] = v
+            return 0
+        if name == 'map_delete':
+            m = self.eval_expr(call.args[0], env)
+            k = self.eval_expr(call.args[1], env)
+            m.pop(k, None)
+            return 0
+        if name == 'map_get':
+            m = self.eval_expr(call.args[0], env)
+            k = self.eval_expr(call.args[1], env)
+            return m.get(k, 0)
+        if name == 'map_has':
+            m = self.eval_expr(call.args[0], env)
+            k = self.eval_expr(call.args[1], env)
+            return int(k in m)
+        if name == 'map_keys':
+            m = self.eval_expr(call.args[0], env)
+            return list(m.keys())
+        if name == 'set_add':
+            s = self.eval_expr(call.args[0], env)
+            v = self.eval_expr(call.args[1], env)
+            s.add(v)
+            return 0
+        if name == 'set_remove':
+            s = self.eval_expr(call.args[0], env)
+            v = self.eval_expr(call.args[1], env)
+            s.discard(v)
+            return 0
+        if name == 'set_contains':
+            s = self.eval_expr(call.args[0], env)
+            v = self.eval_expr(call.args[1], env)
+            return int(v in s)
+        if name == 'set_items':
+            s = self.eval_expr(call.args[0], env)
+            return list(s)
+
+        func = self.functions.get(name)
+        if not func:
+            raise NameError(f'Undefined function {name}')
+        if len(call.args) != len(func.params):
+            raise TypeError('Argument count mismatch')
+        new_env = Environment(env)
+        for name, arg in zip(func.params, call.args):
+            new_env.define(name, self.eval_expr(arg, env))
+        self.exec_stmt_list(func.body, new_env)
+        return self.eval_expr(func.ret, new_env)
+
+    def make_pointer(self, target, env):
+        if isinstance(target, Identifier):
+            e = env.lookup_env(target.name)
+            return Pointer(e, target.name)
+        if isinstance(target, ArrayAccess):
+            arr = self.eval_expr(target.array, env)
+            idx = self.eval_expr(target.index, env)
+            return Pointer(arr, idx)
+        if isinstance(target, FieldAccess):
+            obj = self.eval_expr(target.obj, env)
+            return Pointer(obj, target.field)
+        raise RuntimeError('Address-of operand must be a variable')

--- a/l25_compiler/interpreter.py
+++ b/l25_compiler/interpreter.py
@@ -159,6 +159,11 @@ class Interpreter:
         elif isinstance(stmt, While):
             while self.eval_expr(stmt.cond, env):
                 self.exec_stmt_list(stmt.body, Environment(env))
+        elif isinstance(stmt, DoUntil):
+            while True:
+                self.exec_stmt_list(stmt.body, Environment(env))
+                if self.eval_expr(stmt.cond, env):
+                    break
         elif isinstance(stmt, Input):
             for name in stmt.names:
                 val = int(input(f'{name}: '))

--- a/l25_compiler/ir.py
+++ b/l25_compiler/ir.py
@@ -1,0 +1,91 @@
+from .ast_nodes import *
+
+class IRGenerator:
+    def expr(self, node):
+        if isinstance(node, Number):
+            return str(node.value)
+        if isinstance(node, Identifier):
+            return node.name
+        if isinstance(node, ArrayAccess):
+            return f"{self.expr(node.array)}[{self.expr(node.index)}]"
+        if isinstance(node, FieldAccess):
+            return f"{self.expr(node.obj)}.{node.field}"
+        if isinstance(node, ArrayLiteral):
+            elems = ', '.join(self.expr(e) for e in node.elements)
+            return f"[{elems}]"
+        if isinstance(node, StructLiteral):
+            elems = ', '.join(f"{k}={self.expr(v)}" for k, v in node.fields.items())
+            return f"struct{{{elems}}}"
+        if isinstance(node, MapLiteral):
+            elems = ', '.join(f"{self.expr(k)}:{self.expr(v)}" for k, v in node.pairs)
+            return f"map{{{elems}}}"
+        if isinstance(node, SetLiteral):
+            elems = ', '.join(self.expr(e) for e in node.elements)
+            return f"set{{{elems}}}"
+        if isinstance(node, UnaryOp):
+            return f"({node.op}{self.expr(node.operand)})"
+        if isinstance(node, BinaryOp):
+            return f"({self.expr(node.left)} {node.op} {self.expr(node.right)})"
+        if isinstance(node, FuncCall):
+            args = ', '.join(self.expr(a) for a in node.args)
+            return f"{node.name}({args})"
+        raise RuntimeError('Unknown expr')
+
+    def stmt(self, node, indent=0):
+        sp = ' ' * indent
+        if isinstance(node, Declare):
+            if node.size is not None:
+                size = self.expr(node.size)
+                return [f"{sp}let {node.name}[{size}]"]
+            if node.expr is not None:
+                return [f"{sp}let {node.name} = {self.expr(node.expr)}"]
+            return [f"{sp}let {node.name}"]
+        if isinstance(node, Assign):
+            return [f"{sp}{self.expr(node.target)} = {self.expr(node.expr)}"]
+        if isinstance(node, Input):
+            return [f"{sp}input {', '.join(node.names)}"]
+        if isinstance(node, Output):
+            exprs = ', '.join(self.expr(e) for e in node.exprs)
+            return [f"{sp}output {exprs}"]
+        if isinstance(node, FuncCall):
+            return [f"{sp}{self.expr(node)}"]
+        if isinstance(node, If):
+            lines = [f"{sp}if {self.expr(node.cond)} {{"]
+            for s in node.then.stmts:
+                lines += self.stmt(s, indent + 2)
+            if node.else_:
+                lines.append(f"{sp}}} else {{")
+                for s in node.else_.stmts:
+                    lines += self.stmt(s, indent + 2)
+            lines.append(f"{sp}}}")
+            return lines
+        if isinstance(node, While):
+            lines = [f"{sp}while {self.expr(node.cond)} {{"]
+            for s in node.body.stmts:
+                lines += self.stmt(s, indent + 2)
+            lines.append(f"{sp}}}")
+            return lines
+        raise RuntimeError('Unknown stmt')
+
+    def stmt_list(self, stmt_list, indent=0):
+        lines = []
+        for s in stmt_list.stmts:
+            lines += self.stmt(s, indent)
+        return lines
+
+    def func(self, func):
+        lines = [f"func {func.name}({', '.join(func.params)}) {{"]
+        lines += self.stmt_list(func.body, 2)
+        lines.append(f"  return {self.expr(func.ret)};")
+        lines.append("}")
+        return lines
+
+    def generate(self, ast):
+        lines = [f"program {ast.name} {{"]
+        for f in ast.funcs:
+            lines += self.func(f)
+        lines.append("main {")
+        lines += self.stmt_list(ast.main, 2)
+        lines.append("}")
+        lines.append("}")
+        return lines

--- a/l25_compiler/ir.py
+++ b/l25_compiler/ir.py
@@ -65,6 +65,12 @@ class IRGenerator:
                 lines += self.stmt(s, indent + 2)
             lines.append(f"{sp}}}")
             return lines
+        if isinstance(node, DoUntil):
+            lines = [f"{sp}do {{"]
+            for s in node.body.stmts:
+                lines += self.stmt(s, indent + 2)
+            lines.append(f"{sp}}} until {self.expr(node.cond)}")
+            return lines
         raise RuntimeError('Unknown stmt')
 
     def stmt_list(self, stmt_list, indent=0):

--- a/l25_compiler/lexer.py
+++ b/l25_compiler/lexer.py
@@ -24,7 +24,7 @@ TOKEN_SPEC = [
 tok_regex = '|'.join('(?P<%s>%s)' % pair for pair in TOKEN_SPEC)
 
 KEYWORDS = {
-    'program', 'func', 'return', 'if', 'else', 'while',
+    'program', 'func', 'return', 'if', 'else', 'while', 'do', 'until',
     'let', 'input', 'output', 'main', 'struct', 'map', 'set'
 }
 

--- a/l25_compiler/lexer.py
+++ b/l25_compiler/lexer.py
@@ -1,0 +1,62 @@
+# Token types for L25 language
+import re
+
+TOKEN_SPEC = [
+    ('NUMBER', r'\d+'),
+    ('ID', r'[A-Za-z_][A-Za-z0-9_]*'),
+    ('OP', r'==|!=|<=|>=|[+\-*/=<&>]'),
+    ('LPAREN', r'\('),
+    ('RPAREN', r'\)'),
+    ('LBRACE', r'\{'),
+    ('RBRACE', r'\}'),
+    ('LBRACKET', r'\['),
+    ('RBRACKET', r'\]'),
+    ('DOT', r'\.'),
+    ('COMMA', r','),
+    ('SEMICOLON', r';'),
+    ('COLON', r':'),
+    ('STRING', r'"[^"\\]*(?:\\.[^"\\]*)*"'),
+    ('NEWLINE', r'\n'),
+    ('SKIP', r'[ \t]+'),
+    ('MISMATCH', r'.'),
+]
+
+tok_regex = '|'.join('(?P<%s>%s)' % pair for pair in TOKEN_SPEC)
+
+KEYWORDS = {
+    'program', 'func', 'return', 'if', 'else', 'while',
+    'let', 'input', 'output', 'main', 'struct', 'map', 'set'
+}
+
+class Token:
+    def __init__(self, type_, value, line, column):
+        self.type = type_
+        self.value = value
+        self.line = line
+        self.column = column
+
+    def __repr__(self):
+        return f"Token({self.type}, {self.value}, {self.line}, {self.column})"
+
+
+def tokenize(code):
+    line_num = 1
+    line_start = 0
+    for mo in re.finditer(tok_regex, code):
+        kind = mo.lastgroup
+        value = mo.group()
+        column = mo.start() - line_start
+        if kind == 'NUMBER':
+            value = int(value)
+        if kind == 'NEWLINE':
+            line_num += 1
+            line_start = mo.end()
+            continue
+        elif kind == 'SKIP':
+            continue
+        elif kind == 'ID' and value in KEYWORDS:
+            kind = value.upper()
+        elif kind == 'MISMATCH':
+            raise RuntimeError(f'{value!r} unexpected on line {line_num}')
+        yield Token(kind, value, line_num, column)
+    yield Token('EOF', '', line_num, 0)

--- a/l25_compiler/main.py
+++ b/l25_compiler/main.py
@@ -1,0 +1,57 @@
+import argparse
+from .lexer import tokenize
+from .parser import Parser
+from .interpreter import Interpreter
+from .utils import dump_ast
+from .ir import IRGenerator
+from .tac import ThreeAddressGenerator
+
+
+def main():
+    parser = argparse.ArgumentParser(description="L25 compiler")
+    parser.add_argument("source", help="L25 source file")
+    parser.add_argument("--tokens", action="store_true", help="print tokens and exit")
+    parser.add_argument("--ast", action="store_true", help="print AST and exit unless --ir or execution requested")
+    parser.add_argument("--ir", action="store_true", help="print intermediate representation")
+    parser.add_argument("--tac", action="store_true", help="print three-address code")
+    parser.add_argument("--no-run", action="store_true", help="do not execute program")
+    args = parser.parse_args()
+
+    with open(args.source) as f:
+        code = f.read()
+
+    tokens = list(tokenize(code))
+    if args.tokens:
+        for t in tokens:
+            print(t)
+        if not (args.ast or args.ir or args.tac or not args.no_run):
+            return
+
+    parser_obj = Parser(tokens)
+    ast = parser_obj.parse()
+    if args.ast:
+        for line in dump_ast(ast):
+            print(line)
+        if not (args.ir or args.tac or not args.no_run):
+            return
+
+    ir_lines = IRGenerator().generate(ast)
+    tac_lines = ThreeAddressGenerator().generate(ast)
+    if args.ir:
+        for line in ir_lines:
+            print(line)
+        if args.no_run and not args.tac:
+            return
+
+    if args.tac:
+        for line in tac_lines:
+            print(line)
+        if args.no_run:
+            return
+
+    if not args.no_run:
+        interpreter = Interpreter(ast)
+        interpreter.run()
+
+if __name__ == "__main__":
+    main()

--- a/l25_compiler/main.py
+++ b/l25_compiler/main.py
@@ -1,7 +1,7 @@
 import argparse
 from .lexer import tokenize
 from .parser import Parser
-from .interpreter import Interpreter
+from .pcode_vm import PCodeVM
 from .utils import dump_ast
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
@@ -59,8 +59,10 @@ def main():
             return
 
     if not args.no_run:
-        interpreter = Interpreter(ast)
-        interpreter.run()
+        vm = PCodeVM(pcode_lines, ast)
+        output = vm.run()
+        if output:
+            print(output)
 
 if __name__ == "__main__":
     main()

--- a/l25_compiler/main.py
+++ b/l25_compiler/main.py
@@ -5,6 +5,7 @@ from .interpreter import Interpreter
 from .utils import dump_ast
 from .ir import IRGenerator
 from .tac import ThreeAddressGenerator
+from .pcode import PCodeGenerator
 
 
 def main():
@@ -14,6 +15,7 @@ def main():
     parser.add_argument("--ast", action="store_true", help="print AST and exit unless --ir or execution requested")
     parser.add_argument("--ir", action="store_true", help="print intermediate representation")
     parser.add_argument("--tac", action="store_true", help="print three-address code")
+    parser.add_argument("--pcode", action="store_true", help="print pcode instructions")
     parser.add_argument("--no-run", action="store_true", help="do not execute program")
     args = parser.parse_args()
 
@@ -24,7 +26,7 @@ def main():
     if args.tokens:
         for t in tokens:
             print(t)
-        if not (args.ast or args.ir or args.tac or not args.no_run):
+        if not (args.ast or args.ir or args.tac or args.pcode or not args.no_run):
             return
 
     parser_obj = Parser(tokens)
@@ -32,19 +34,26 @@ def main():
     if args.ast:
         for line in dump_ast(ast):
             print(line)
-        if not (args.ir or args.tac or not args.no_run):
+        if not (args.ir or args.tac or args.pcode or not args.no_run):
             return
 
     ir_lines = IRGenerator().generate(ast)
     tac_lines = ThreeAddressGenerator().generate(ast)
+    pcode_lines = PCodeGenerator().generate(ast)
     if args.ir:
         for line in ir_lines:
             print(line)
-        if args.no_run and not args.tac:
+        if args.no_run and not (args.tac or args.pcode):
             return
 
     if args.tac:
         for line in tac_lines:
+            print(line)
+        if args.no_run and not args.pcode:
+            return
+
+    if args.pcode:
+        for line in pcode_lines:
             print(line)
         if args.no_run:
             return

--- a/l25_compiler/parser.py
+++ b/l25_compiler/parser.py
@@ -94,6 +94,8 @@ class Parser:
             return self.if_stmt()
         if tok.type == 'WHILE':
             return self.while_stmt()
+        if tok.type == 'DO':
+            return self.do_until_stmt()
         if tok.type == 'INPUT':
             return self.input_stmt()
         if tok.type == 'OUTPUT':
@@ -153,6 +155,18 @@ class Parser:
         body = self.stmt_list()
         self.expect('RBRACE')
         return While(cond, body)
+
+    # do_until_stmt = 'do' '{' stmt_list '}' 'until' '(' bool_expr ')'
+    def do_until_stmt(self):
+        self.expect('DO')
+        self.expect('LBRACE')
+        body = self.stmt_list()
+        self.expect('RBRACE')
+        self.expect('UNTIL')
+        self.expect('LPAREN')
+        cond = self.bool_expr()
+        self.expect('RPAREN')
+        return DoUntil(cond, body)
 
     # func_call = ident "(" [ arg_list ] ")"
     def func_call(self):

--- a/l25_compiler/parser.py
+++ b/l25_compiler/parser.py
@@ -1,0 +1,325 @@
+from .lexer import tokenize
+from .ast_nodes import *
+
+class ParserError(Exception):
+    pass
+
+class Parser:
+    def __init__(self, tokens):
+        self.tokens = list(tokens)
+        self.pos = 0
+
+    def current(self):
+        return self.tokens[self.pos]
+
+    def accept(self, *types):
+        tok = self.current()
+        if tok.type in types:
+            self.pos += 1
+            return tok
+        return None
+
+    def expect(self, *types):
+        tok = self.accept(*types)
+        if not tok:
+            raise ParserError(f'Expected {types}, got {self.current().type}')
+        return tok
+
+    def parse(self):
+        return self.program()
+
+    # program = "program" ident "{" { func_def } "main" "{" stmt_list "}" "}"
+    def program(self):
+        self.expect('PROGRAM')
+        name = self.expect('ID').value
+        self.expect('LBRACE')
+        funcs = []
+        while self.accept('FUNC'):
+            self.pos -= 1
+            funcs.append(self.func_def())
+        self.expect('MAIN')
+        self.expect('LBRACE')
+        main_body = self.stmt_list()
+        self.expect('RBRACE')
+        self.expect('RBRACE')
+        return Program(name, funcs, main_body)
+
+    # func_def = "func" ident "(" [ param_list ] ")" "{" stmt_list "return" expr ";" "}"
+    def func_def(self):
+        self.expect('FUNC')
+        name = self.expect('ID').value
+        self.expect('LPAREN')
+        params = []
+        if not self.accept('RPAREN'):
+            params.append(self.expect('ID').value)
+            while self.accept('COMMA'):
+                params.append(self.expect('ID').value)
+            self.expect('RPAREN')
+        self.expect('LBRACE')
+        body = self.stmt_list()
+        self.expect('RETURN')
+        ret = self.expr()
+        self.expect('SEMICOLON')
+        self.expect('RBRACE')
+        return FuncDef(name, params, body, ret)
+
+    # stmt_list = stmt ";" { stmt ";" }
+    def stmt_list(self):
+        stmts = [self.stmt()]
+        self.expect('SEMICOLON')
+        while True:
+            mark = self.pos
+            try:
+                stmts.append(self.stmt())
+                self.expect('SEMICOLON')
+            except ParserError:
+                self.pos = mark
+                break
+        return StmtList(stmts)
+
+    # stmt options
+    def stmt(self):
+        tok = self.current()
+        if tok.type == 'LET':
+            return self.declare_stmt()
+        if tok.type == 'ID':
+            # could be assign or func_call
+            if self.tokens[self.pos + 1].type == 'LPAREN':
+                return self.func_call()
+            else:
+                return self.assign_stmt()
+        if tok.type == 'OP' and tok.value == '*':
+            return self.assign_stmt()
+        if tok.type == 'IF':
+            return self.if_stmt()
+        if tok.type == 'WHILE':
+            return self.while_stmt()
+        if tok.type == 'INPUT':
+            return self.input_stmt()
+        if tok.type == 'OUTPUT':
+            return self.output_stmt()
+        raise ParserError(f'Unexpected token {tok.type}')
+
+    # declare_stmt = "let" ident [ "[" expr "]" ] [ "=" expr ]
+    def declare_stmt(self):
+        self.expect('LET')
+        name = self.expect('ID').value
+        size = None
+        if self.accept('LBRACKET'):
+            size = self.expr()
+            self.expect('RBRACKET')
+        expr = None
+        if self.accept('OP') and self.tokens[self.pos-1].value == '=':
+            expr = self.expr()
+        else:
+            self.pos -= 1 if self.tokens[self.pos-1].type == 'OP' else 0
+        return Declare(name, expr, size)
+
+    # assign_stmt = assign_target "=" expr
+    def assign_stmt(self):
+        target = self.assign_target()
+        self.expect('OP')  # '='
+        expr = self.expr()
+        return Assign(target, expr)
+
+    def assign_target(self):
+        if self.accept('OP') and self.tokens[self.pos-1].value == '*':
+            return UnaryOp('*', self.assign_target())
+        return self.variable()
+
+    # if_stmt = "if" "(" bool_expr ")" "{" stmt_list "}" [ "else" "{" stmt_list "}" ]
+    def if_stmt(self):
+        self.expect('IF')
+        self.expect('LPAREN')
+        cond = self.bool_expr()
+        self.expect('RPAREN')
+        self.expect('LBRACE')
+        then = self.stmt_list()
+        self.expect('RBRACE')
+        else_ = None
+        if self.accept('ELSE'):
+            self.expect('LBRACE')
+            else_ = self.stmt_list()
+            self.expect('RBRACE')
+        return If(cond, then, else_)
+
+    # while_stmt = "while" "(" bool_expr ")" "{" stmt_list "}"
+    def while_stmt(self):
+        self.expect('WHILE')
+        self.expect('LPAREN')
+        cond = self.bool_expr()
+        self.expect('RPAREN')
+        self.expect('LBRACE')
+        body = self.stmt_list()
+        self.expect('RBRACE')
+        return While(cond, body)
+
+    # func_call = ident "(" [ arg_list ] ")"
+    def func_call(self):
+        name = self.expect('ID').value
+        self.expect('LPAREN')
+        args = []
+        if not self.accept('RPAREN'):
+            args.append(self.expr())
+            while self.accept('COMMA'):
+                args.append(self.expr())
+            self.expect('RPAREN')
+        return FuncCall(name, args)
+
+    # variable = ident { '[' expr ']' | '.' ident }
+    def variable(self):
+        node = Identifier(self.expect('ID').value)
+        while True:
+            if self.accept('LBRACKET'):
+                idx = self.expr()
+                self.expect('RBRACKET')
+                node = ArrayAccess(node, idx)
+            elif self.accept('DOT'):
+                field = self.expect('ID').value
+                node = FieldAccess(node, field)
+            else:
+                break
+        return node
+
+    def array_literal(self):
+        self.expect('LBRACKET')
+        elems = []
+        if not self.accept('RBRACKET'):
+            elems.append(self.expr())
+            while self.accept('COMMA'):
+                elems.append(self.expr())
+            self.expect('RBRACKET')
+        return ArrayLiteral(elems)
+
+    def struct_literal(self):
+        self.expect('STRUCT')
+        self.expect('LBRACE')
+        fields = {}
+        if self.current().type != 'RBRACE':
+            while True:
+                name = self.expect('ID').value
+                self.expect('OP')  # '='
+                fields[name] = self.expr()
+                if self.accept('SEMICOLON'):
+                    if self.current().type == 'RBRACE':
+                        break
+                else:
+                    break
+        self.expect('RBRACE')
+        return StructLiteral(fields)
+
+    def map_literal(self):
+        self.expect('MAP')
+        self.expect('LBRACE')
+        pairs = []
+        if self.current().type != 'RBRACE':
+            while True:
+                key = self.expr()
+                self.expect('COLON')
+                val = self.expr()
+                pairs.append((key, val))
+                if self.accept('SEMICOLON'):
+                    if self.current().type == 'RBRACE':
+                        break
+                else:
+                    break
+        self.expect('RBRACE')
+        return MapLiteral(pairs)
+
+    def set_literal(self):
+        self.expect('SET')
+        self.expect('LBRACE')
+        elems = []
+        if self.current().type != 'RBRACE':
+            while True:
+                elems.append(self.expr())
+                if self.accept('SEMICOLON'):
+                    if self.current().type == 'RBRACE':
+                        break
+                else:
+                    break
+        self.expect('RBRACE')
+        return SetLiteral(elems)
+
+    # input_stmt = "input" "(" ident { "," ident } ")"
+    def input_stmt(self):
+        self.expect('INPUT')
+        self.expect('LPAREN')
+        names = [self.expect('ID').value]
+        while self.accept('COMMA'):
+            names.append(self.expect('ID').value)
+        self.expect('RPAREN')
+        return Input(names)
+
+    # output_stmt = "output" "(" expr { "," expr } ")"
+    def output_stmt(self):
+        self.expect('OUTPUT')
+        self.expect('LPAREN')
+        exprs = [self.expr()]
+        while self.accept('COMMA'):
+            exprs.append(self.expr())
+        self.expect('RPAREN')
+        return Output(exprs)
+
+    # bool_expr = expr ( "==" | "!=" | "<" | "<=" | ">" | ">=" ) expr
+    def bool_expr(self):
+        left = self.expr()
+        op = self.expect('OP').value
+        right = self.expr()
+        return BinaryOp(op, left, right)
+
+    # expr = [ "+" | "-" ] term { ( "+" | "-" ) term }
+    def expr(self):
+        if self.current().type == 'OP' and self.current().value in ('+', '-'):
+            op = self.current().value
+            self.pos += 1
+            node = UnaryOp(op, self.term())
+        else:
+            node = self.term()
+        while self.current().type == 'OP' and self.current().value in ('+', '-'):
+            op = self.current().value
+            self.pos += 1
+            right = self.term()
+            node = BinaryOp(op, node, right)
+        return node
+
+    # term = factor { ( "*" | "/" ) factor }
+    def term(self):
+        node = self.factor()
+        while self.current().type == 'OP' and self.current().value in ('*', '/'):
+            op = self.current().value
+            self.pos += 1
+            right = self.factor()
+            node = BinaryOp(op, node, right)
+        return node
+
+    # factor = ["*" factor | "&" variable | ident | number | "(" expr ")" | func_call | array_literal | struct_literal]
+    def factor(self):
+        tok = self.current()
+        if tok.type == 'NUMBER':
+            self.pos += 1
+            return Number(tok.value)
+        if tok.type == 'OP' and tok.value == '&':
+            self.pos += 1
+            return UnaryOp('&', self.variable())
+        if tok.type == 'OP' and tok.value == '*':
+            self.pos += 1
+            return UnaryOp('*', self.factor())
+        if tok.type == 'ID':
+            if self.tokens[self.pos+1].type == 'LPAREN':
+                return self.func_call()
+            else:
+                return self.variable()
+        if tok.type == 'LBRACKET':
+            return self.array_literal()
+        if tok.type == 'STRUCT':
+            return self.struct_literal()
+        if tok.type == 'MAP':
+            return self.map_literal()
+        if tok.type == 'SET':
+            return self.set_literal()
+        if self.accept('LPAREN'):
+            node = self.expr()
+            self.expect('RPAREN')
+            return node
+        raise ParserError(f'Unexpected factor {tok.type}')

--- a/l25_compiler/pcode.py
+++ b/l25_compiler/pcode.py
@@ -115,6 +115,13 @@ class PCodeGenerator:
                 self.stmt(s)
             self.emit(f"JMP {start}")
             self.emit(f"{end}:")
+        elif isinstance(node, DoUntil):
+            start = self.new_label()
+            self.emit(f"{start}:")
+            for s in node.body.stmts:
+                self.stmt(s)
+            self.expr(node.cond)
+            self.emit(f"JZ {start}")
         else:
             raise RuntimeError('Unknown statement')
 

--- a/l25_compiler/pcode.py
+++ b/l25_compiler/pcode.py
@@ -1,0 +1,155 @@
+from .ast_nodes import *
+
+class PCodeGenerator:
+    def __init__(self):
+        self.lines = []
+        self.label = 0
+
+    def new_label(self):
+        self.label += 1
+        return f"L{self.label}"
+
+    def emit(self, line):
+        self.lines.append(line)
+
+    def expr(self, node):
+        if isinstance(node, Number):
+            self.emit(f"PUSH {node.value}")
+        elif isinstance(node, Identifier):
+            self.emit(f"LOAD {node.name}")
+        elif isinstance(node, ArrayAccess):
+            self.expr(node.array)
+            self.expr(node.index)
+            self.emit("ALOAD")
+        elif isinstance(node, FieldAccess):
+            self.expr(node.obj)
+            self.emit(f"FLOAD {node.field}")
+        elif isinstance(node, ArrayLiteral):
+            for e in node.elements:
+                self.expr(e)
+            self.emit(f"ARRAY {len(node.elements)}")
+        elif isinstance(node, StructLiteral):
+            for k, v in node.fields.items():
+                self.expr(v)
+                self.emit(f"SETFIELD {k}")
+            self.emit("STRUCT")
+        elif isinstance(node, MapLiteral):
+            for k, v in node.pairs:
+                self.expr(k)
+                self.expr(v)
+                self.emit("MAP_INSERT")
+            self.emit("MAP")
+        elif isinstance(node, SetLiteral):
+            for e in node.elements:
+                self.expr(e)
+                self.emit("SET_ADD")
+            self.emit("SET")
+        elif isinstance(node, UnaryOp):
+            self.expr(node.operand)
+            if node.op == '-':
+                self.emit('NEG')
+            elif node.op == '+':
+                pass
+            elif node.op == '&':
+                self.emit('ADDR')
+            elif node.op == '*':
+                self.emit('DEREF')
+        elif isinstance(node, BinaryOp):
+            self.expr(node.left)
+            self.expr(node.right)
+            opmap = {'+':'ADD','-':'SUB','*':'MUL','/':'DIV',
+                     '==':'EQ','!=':'NE','<':'LT','<=':'LE','>':'GT','>=':'GE'}
+            self.emit(opmap.get(node.op, node.op))
+        elif isinstance(node, FuncCall):
+            for a in node.args:
+                self.expr(a)
+            self.emit(f"CALL {node.name} {len(node.args)}")
+        else:
+            raise RuntimeError('Unknown expression')
+
+    def stmt(self, node):
+        if isinstance(node, Declare):
+            if node.size is not None:
+                self.expr(node.size)
+                self.emit(f"DECL_ARR {node.name}")
+            elif node.expr is not None:
+                self.expr(node.expr)
+                self.emit(f"STORE {node.name}")
+            else:
+                self.emit(f"DECL {node.name}")
+        elif isinstance(node, Assign):
+            self.expr(node.expr)
+            self.store_target(node.target)
+        elif isinstance(node, Input):
+            for n in node.names:
+                self.emit(f"READ {n}")
+        elif isinstance(node, Output):
+            for e in node.exprs:
+                self.expr(e)
+                self.emit("PRINT")
+        elif isinstance(node, FuncCall):
+            self.expr(node)
+            self.emit("POP")
+        elif isinstance(node, If):
+            else_label = self.new_label()
+            end_label = self.new_label() if node.else_ else else_label
+            self.expr(node.cond)
+            self.emit(f"JZ {else_label}")
+            for s in node.then.stmts:
+                self.stmt(s)
+            if node.else_:
+                self.emit(f"JMP {end_label}")
+                self.emit(f"{else_label}:")
+                for s in node.else_.stmts:
+                    self.stmt(s)
+                self.emit(f"{end_label}:")
+            else:
+                self.emit(f"{else_label}:")
+        elif isinstance(node, While):
+            start = self.new_label()
+            end = self.new_label()
+            self.emit(f"{start}:")
+            self.expr(node.cond)
+            self.emit(f"JZ {end}")
+            for s in node.body.stmts:
+                self.stmt(s)
+            self.emit(f"JMP {start}")
+            self.emit(f"{end}:")
+        else:
+            raise RuntimeError('Unknown statement')
+
+    def store_target(self, target):
+        if isinstance(target, Identifier):
+            self.emit(f"STORE {target.name}")
+        elif isinstance(target, ArrayAccess):
+            self.expr(target.array)
+            self.expr(target.index)
+            self.emit("ASTORE")
+        elif isinstance(target, FieldAccess):
+            self.expr(target.obj)
+            self.emit(f"FSTORE {target.field}")
+        elif isinstance(target, UnaryOp) and target.op == '*':
+            self.expr(target.operand)
+            self.emit("PSTORE")
+        else:
+            raise RuntimeError('Invalid assignment target')
+
+    def stmt_list(self, sl):
+        for s in sl.stmts:
+            self.stmt(s)
+
+    def func(self, f):
+        self.emit(f"FUNC {f.name}")
+        for s in f.body.stmts:
+            self.stmt(s)
+        self.expr(f.ret)
+        self.emit("RET")
+
+    def generate(self, ast):
+        self.emit(f"PROGRAM {ast.name}")
+        for f in ast.funcs:
+            self.func(f)
+        self.emit("MAIN")
+        self.stmt_list(ast.main)
+        self.emit("END")
+        return self.lines

--- a/l25_compiler/pcode_vm.py
+++ b/l25_compiler/pcode_vm.py
@@ -1,0 +1,280 @@
+from .ast_nodes import FuncDef
+
+class Environment:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.vars = {}
+
+    def get(self, name):
+        if name in self.vars:
+            return self.vars[name]
+        if self.parent:
+            return self.parent.get(name)
+        raise NameError(f"Undefined variable {name}")
+
+    def set(self, name, value):
+        if name in self.vars:
+            self.vars[name] = value
+        elif self.parent:
+            self.parent.set(name, value)
+        else:
+            raise NameError(f"Undefined variable {name}")
+
+    def define(self, name, value=0):
+        self.vars[name] = value
+
+    def lookup_env(self, name):
+        if name in self.vars:
+            return self
+        if self.parent:
+            return self.parent.lookup_env(name)
+        raise NameError(f"Undefined variable {name}")
+
+class Pointer:
+    def __init__(self, container, key):
+        self.container = container
+        self.key = key
+
+    def get(self):
+        if isinstance(self.container, Environment):
+            return self.container.vars[self.key]
+        return self.container[self.key]
+
+    def set(self, value):
+        if isinstance(self.container, Environment):
+            self.container.vars[self.key] = value
+        else:
+            self.container[self.key] = value
+
+class PCodeVM:
+    def __init__(self, lines, ast):
+        self.lines = lines
+        self.ast = ast
+        self.stack = []
+        self.env_stack = [Environment()]
+        self.call_stack = []
+        self.labels = {}
+        self.func_addrs = {}
+        self.func_defs = {f.name: f for f in ast.funcs}
+        self._preprocess()
+        self.output_lines = []
+        self.current_line = []
+        self.input_iter = iter([])
+        self.prev_instr = None
+
+    def _preprocess(self):
+        for idx, line in enumerate(self.lines):
+            if line.endswith(':'):
+                self.labels[line[:-1]] = idx
+            elif line.startswith('FUNC '):
+                name = line.split()[1]
+                self.func_addrs[name] = idx + 1
+            elif line.startswith('MAIN'):
+                self.main_addr = idx + 1
+
+    def run(self, inputs=None):
+        if inputs is None:
+            inputs = []
+        self.input_iter = iter(inputs)
+        ip = self.main_addr
+        while ip < len(self.lines):
+            parts = self.lines[ip].split()
+            if not parts:
+                ip += 1
+                continue
+            instr = parts[0]
+            if instr.endswith(':'):
+                ip += 1
+                continue
+            if instr == 'END':
+                self._flush_line()
+                break
+            ip = self._exec(instr, parts[1:], ip)
+            self.prev_instr = instr
+        return '\n'.join(self.output_lines).strip()
+
+    def _flush_line(self):
+        if self.current_line:
+            self.output_lines.append(' '.join(self.current_line))
+            self.current_line = []
+
+    def _pop(self):
+        if not self.stack:
+            raise RuntimeError('Stack underflow')
+        return self.stack.pop()
+
+    def _exec(self, instr, args, ip):
+        env = self.env_stack[-1]
+        if instr == 'PUSH':
+            self.stack.append(int(args[0]))
+        elif instr == 'LOAD':
+            self.stack.append(env.get(args[0]))
+        elif instr == 'DECL':
+            env.define(args[0], 0)
+        elif instr == 'DECL_ARR':
+            size = self._pop()
+            env.define(args[0], [0]*size)
+        elif instr == 'STORE':
+            val = self._pop()
+            try:
+                env.lookup_env(args[0]).set(args[0], val)
+            except NameError:
+                env.define(args[0], val)
+        elif instr == 'READ':
+            try:
+                val_str = next(self.input_iter)
+            except StopIteration:
+                val_str = input(f"{args[0]}: ")
+            val = int(val_str)
+            try:
+                env.lookup_env(args[0]).set(args[0], val)
+            except NameError:
+                env.define(args[0], val)
+        elif instr == 'PRINT':
+            val = self._pop()
+            self.current_line.append(str(val))
+        elif instr == 'NEWLINE':
+            self._flush_line()
+        elif instr == 'POP':
+            self._pop()
+        elif instr == 'JZ':
+            val = self._pop()
+            if val == 0:
+                return self.labels[args[0]]
+        elif instr == 'JMP':
+            return self.labels[args[0]]
+        elif instr == 'ADD':
+            b, a = self._pop(), self._pop()
+            self.stack.append(a + b)
+        elif instr == 'SUB':
+            b, a = self._pop(), self._pop()
+            self.stack.append(a - b)
+        elif instr == 'MUL':
+            b, a = self._pop(), self._pop()
+            self.stack.append(a * b)
+        elif instr == 'DIV':
+            b, a = self._pop(), self._pop()
+            self.stack.append(a // b)
+        elif instr == 'EQ':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a == b))
+        elif instr == 'NE':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a != b))
+        elif instr == 'LT':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a < b))
+        elif instr == 'LE':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a <= b))
+        elif instr == 'GT':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a > b))
+        elif instr == 'GE':
+            b, a = self._pop(), self._pop()
+            self.stack.append(int(a >= b))
+        elif instr == 'NEG':
+            a = self._pop()
+            self.stack.append(-a)
+        elif instr == 'ADDR':
+            self.stack.append(Pointer(env.lookup_env(args[0]), args[0]))
+        elif instr == 'DEREF':
+            ptr = self._pop()
+            if not isinstance(ptr, Pointer):
+                raise RuntimeError('DEREF of non-pointer')
+            self.stack.append(ptr.get())
+        elif instr == 'AADDR':
+            idx = self._pop()
+            arr = self._pop()
+            self.stack.append(Pointer(arr, idx))
+        elif instr == 'FADDR':
+            obj = self._pop()
+            self.stack.append(Pointer(obj, args[0]))
+        elif instr == 'PSTORE':
+            ptr = self._pop()
+            val = self._pop()
+            if not isinstance(ptr, Pointer):
+                raise RuntimeError('PSTORE to non-pointer')
+            ptr.set(val)
+        elif instr == 'ALOAD':
+            idx = self._pop()
+            arr = self._pop()
+            self.stack.append(arr[idx])
+        elif instr == 'ASTORE':
+            idx = self._pop()
+            arr = self._pop()
+            val = self._pop()
+            arr[idx] = val
+        elif instr == 'FLOAD':
+            obj = self._pop()
+            self.stack.append(obj.get(args[0]))
+        elif instr == 'FSTORE':
+            obj = self._pop()
+            val = self._pop()
+            obj[args[0]] = val
+        elif instr == 'SETFIELD':
+            val = self._pop()
+            self.stack.append(('FIELD', args[0], val))
+        elif instr == 'STRUCT':
+            d = {}
+            while self.stack and isinstance(self.stack[-1], tuple) and self.stack[-1][0] == 'FIELD':
+                _, k, v = self.stack.pop()
+                d[k] = v
+            self.stack.append(d)
+        elif instr == 'SET_ADD':
+            val = self._pop()
+            self.stack.append(('SET', val))
+        elif instr == 'SET':
+            s = set()
+            while self.stack and isinstance(self.stack[-1], tuple) and self.stack[-1][0] == 'SET':
+                _, v = self.stack.pop()
+                s.add(v)
+            self.stack.append(s)
+        elif instr == 'MAP_INSERT':
+            val = self._pop()
+            key = self._pop()
+            self.stack.append(('MAP', key, val))
+        elif instr == 'MAP':
+            m = {}
+            while self.stack and isinstance(self.stack[-1], tuple) and self.stack[-1][0] == 'MAP':
+                _, k, v = self.stack.pop()
+                m[k] = v
+            self.stack.append(m)
+        elif instr == 'CALL':
+            name = args[0]
+            argc = int(args[1])
+            params = [self._pop() for _ in range(argc)][::-1]
+            if name in self._builtins():
+                res = self._builtins()[name](*params)
+                self.stack.append(res)
+            else:
+                func_ip = self.func_addrs[name]
+                func_def = self.func_defs[name]
+                new_env = Environment(self.env_stack[-1])
+                for p, v in zip(func_def.params, params):
+                    new_env.define(p, v)
+                self.env_stack.append(new_env)
+                self.call_stack.append(ip + 1)
+                return func_ip
+        elif instr == 'RET':
+            ret = self._pop()
+            self.env_stack.pop()
+            ip = self.call_stack.pop()
+            self.stack.append(ret)
+            return ip
+        else:
+            raise RuntimeError(f'Unknown instruction {instr}')
+        return ip + 1
+
+    def _builtins(self):
+        return {
+            'map_insert': lambda m, k, v: (m.__setitem__(k, v), 0)[1],
+            'map_delete': lambda m, k: (m.pop(k, None), 0)[1],
+            'map_get': lambda m, k: m.get(k, 0),
+            'map_has': lambda m, k: int(k in m),
+            'map_keys': lambda m: list(m.keys()),
+            'set_add': lambda s, v: (s.add(v), 0)[1],
+            'set_remove': lambda s, v: (s.discard(v), 0)[1],
+            'set_contains': lambda s, v: int(v in s),
+            'set_items': lambda s: list(s),
+        }

--- a/l25_compiler/pcode_vm.py
+++ b/l25_compiler/pcode_vm.py
@@ -75,23 +75,30 @@ class PCodeVM:
     def run(self, inputs=None):
         if inputs is None:
             inputs = []
+        self.output_lines = []
+        self.current_line = []
         self.input_iter = iter(inputs)
         ip = self.main_addr
-        while ip < len(self.lines):
-            parts = self.lines[ip].split()
-            if not parts:
-                ip += 1
-                continue
-            instr = parts[0]
-            if instr.endswith(':'):
-                ip += 1
-                continue
-            if instr == 'END':
-                self._flush_line()
-                break
-            ip = self._exec(instr, parts[1:], ip)
-            self.prev_instr = instr
-        return '\n'.join(self.output_lines).strip()
+        try:
+            while ip < len(self.lines):
+                parts = self.lines[ip].split()
+                if not parts:
+                    ip += 1
+                    continue
+                instr = parts[0]
+                if instr.endswith(':'):
+                    ip += 1
+                    continue
+                if instr == 'END':
+                    self._flush_line()
+                    break
+                ip = self._exec(instr, parts[1:], ip)
+                self.prev_instr = instr
+            self._flush_line()
+            return '\n'.join(self.output_lines).strip()
+        except Exception:
+            self._flush_line()
+            raise
 
     def _flush_line(self):
         if self.current_line:

--- a/l25_compiler/tac.py
+++ b/l25_compiler/tac.py
@@ -1,0 +1,127 @@
+from .ast_nodes import *
+
+class ThreeAddressGenerator:
+    def __init__(self):
+        self.temp = 0
+        self.label = 0
+        self.lines = []
+
+    def new_temp(self):
+        self.temp += 1
+        return f"t{self.temp}"
+
+    def new_label(self):
+        self.label += 1
+        return f"L{self.label}"
+
+    def expr(self, node):
+        if isinstance(node, Number):
+            return str(node.value)
+        if isinstance(node, Identifier):
+            return node.name
+        if isinstance(node, ArrayAccess):
+            arr = self.expr(node.array)
+            idx = self.expr(node.index)
+            return f"{arr}[{idx}]"
+        if isinstance(node, FieldAccess):
+            obj = self.expr(node.obj)
+            return f"{obj}.{node.field}"
+        if isinstance(node, ArrayLiteral):
+            elems = ', '.join(self.expr(e) for e in node.elements)
+            return f"[{elems}]"
+        if isinstance(node, StructLiteral):
+            parts = ', '.join(f"{k}={self.expr(v)}" for k, v in node.fields.items())
+            return f"struct{{{parts}}}"
+        if isinstance(node, MapLiteral):
+            parts = ', '.join(f"{self.expr(k)}:{self.expr(v)}" for k, v in node.pairs)
+            return f"map{{{parts}}}"
+        if isinstance(node, SetLiteral):
+            parts = ', '.join(self.expr(e) for e in node.elements)
+            return f"set{{{parts}}}"
+        if isinstance(node, UnaryOp):
+            val = self.expr(node.operand)
+            tmp = self.new_temp()
+            self.lines.append(f"{tmp} = {node.op}{val}")
+            return tmp
+        if isinstance(node, BinaryOp):
+            left = self.expr(node.left)
+            right = self.expr(node.right)
+            tmp = self.new_temp()
+            self.lines.append(f"{tmp} = {left} {node.op} {right}")
+            return tmp
+        if isinstance(node, FuncCall):
+            args = [self.expr(a) for a in node.args]
+            tmp = self.new_temp()
+            self.lines.append(f"{tmp} = call {node.name}({', '.join(args)})")
+            return tmp
+        raise RuntimeError('Unknown expression')
+
+    def stmt(self, node):
+        if isinstance(node, Declare):
+            if node.size is not None:
+                size = self.expr(node.size)
+                self.lines.append(f"{node.name} = [0] x {size}")
+            elif node.expr is not None:
+                val = self.expr(node.expr)
+                self.lines.append(f"{node.name} = {val}")
+            else:
+                self.lines.append(f"{node.name} = 0")
+        elif isinstance(node, Assign):
+            val = self.expr(node.expr)
+            target = self.expr(node.target)
+            self.lines.append(f"{target} = {val}")
+        elif isinstance(node, Input):
+            for n in node.names:
+                self.lines.append(f"input {n}")
+        elif isinstance(node, Output):
+            vals = ', '.join(self.expr(e) for e in node.exprs)
+            self.lines.append(f"print {vals}")
+        elif isinstance(node, FuncCall):
+            self.expr(node)
+        elif isinstance(node, If):
+            cond = self.expr(node.cond)
+            label_else = self.new_label()
+            label_end = self.new_label() if node.else_ else label_else
+            self.lines.append(f"if_false {cond} goto {label_else}")
+            for s in node.then.stmts:
+                self.stmt(s)
+            if node.else_:
+                self.lines.append(f"goto {label_end}")
+                self.lines.append(f"{label_else}:")
+                for s in node.else_.stmts:
+                    self.stmt(s)
+                self.lines.append(f"{label_end}:")
+            else:
+                self.lines.append(f"{label_else}:")
+        elif isinstance(node, While):
+            label_start = self.new_label()
+            label_end = self.new_label()
+            self.lines.append(f"{label_start}:")
+            cond = self.expr(node.cond)
+            self.lines.append(f"if_false {cond} goto {label_end}")
+            for s in node.body.stmts:
+                self.stmt(s)
+            self.lines.append(f"goto {label_start}")
+            self.lines.append(f"{label_end}:")
+        else:
+            raise RuntimeError('Unknown statement')
+
+    def stmt_list(self, sl):
+        for s in sl.stmts:
+            self.stmt(s)
+
+    def func(self, f):
+        self.lines.append(f"func {f.name}:")
+        for s in f.body.stmts:
+            self.stmt(s)
+        ret = self.expr(f.ret)
+        self.lines.append(f"return {ret}")
+
+    def generate(self, ast):
+        self.lines.append(f"program {ast.name}")
+        for f in ast.funcs:
+            self.func(f)
+        self.lines.append("main:")
+        self.stmt_list(ast.main)
+        self.lines.append("end")
+        return self.lines

--- a/l25_compiler/tac.py
+++ b/l25_compiler/tac.py
@@ -103,6 +103,13 @@ class ThreeAddressGenerator:
                 self.stmt(s)
             self.lines.append(f"goto {label_start}")
             self.lines.append(f"{label_end}:")
+        elif isinstance(node, DoUntil):
+            label_start = self.new_label()
+            self.lines.append(f"{label_start}:")
+            for s in node.body.stmts:
+                self.stmt(s)
+            cond = self.expr(node.cond)
+            self.lines.append(f"if_false {cond} goto {label_start}")
         else:
             raise RuntimeError('Unknown statement')
 

--- a/l25_compiler/utils.py
+++ b/l25_compiler/utils.py
@@ -80,6 +80,12 @@ def dump_ast(node, indent=0):
         for s in node.body.stmts:
             lines.extend(dump_ast(s, indent + 2))
         return lines
+    if isinstance(node, DoUntil):
+        lines = [f"{sp}do:"]
+        for s in node.body.stmts:
+            lines.extend(dump_ast(s, indent + 2))
+        lines.append(f"{sp}until {dump_ast(node.cond)[0].strip()}")
+        return lines
     if isinstance(node, Return):
         return [f"{sp}return {dump_ast(node.expr)[0].strip()}"]
     raise RuntimeError('Unknown node')

--- a/l25_compiler/utils.py
+++ b/l25_compiler/utils.py
@@ -1,0 +1,85 @@
+from .ast_nodes import *
+
+
+def dump_ast(node, indent=0):
+    sp = ' ' * indent
+    if isinstance(node, Program):
+        lines = [f"{sp}Program({node.name})"]
+        for f in node.funcs:
+            lines.extend(dump_ast(f, indent + 2))
+        lines.append(f"{sp}main:")
+        lines.extend(dump_ast(node.main, indent + 2))
+        return lines
+    if isinstance(node, FuncDef):
+        lines = [f"{sp}FuncDef({node.name} params={node.params})"]
+        lines.extend(dump_ast(node.body, indent + 2))
+        lines.append(f"{sp}return:")
+        lines.extend(dump_ast(node.ret, indent + 2))
+        return lines
+    if isinstance(node, StmtList):
+        lines = []
+        for s in node.stmts:
+            lines.extend(dump_ast(s, indent))
+        return lines
+    if isinstance(node, Declare):
+        if node.size is not None:
+            return [f"{sp}Declare {node.name}[{dump_ast(node.size)[0].strip()}]"]
+        if node.expr is not None:
+            return [f"{sp}Declare {node.name} = {dump_ast(node.expr)[0].strip()}"]
+        return [f"{sp}Declare {node.name}"]
+    if isinstance(node, Assign):
+        return [f"{sp}{dump_ast(node.target)[0].strip()} = {dump_ast(node.expr)[0].strip()}"]
+    if isinstance(node, Identifier):
+        return [f"{sp}{node.name}"]
+    if isinstance(node, Number):
+        return [f"{sp}{node.value}"]
+    if isinstance(node, ArrayAccess):
+        arr = dump_ast(node.array)[0].strip()
+        idx = dump_ast(node.index)[0].strip()
+        return [f"{sp}{arr}[{idx}]"]
+    if isinstance(node, FieldAccess):
+        obj = dump_ast(node.obj)[0].strip()
+        return [f"{sp}{obj}.{node.field}"]
+    if isinstance(node, ArrayLiteral):
+        elems = ', '.join(e.strip() for e in sum((dump_ast(e) for e in node.elements), []))
+        return [f"{sp}[{elems}]"]
+    if isinstance(node, StructLiteral):
+        fields = ', '.join(f"{k}={dump_ast(v)[0].strip()}" for k, v in node.fields.items())
+        return [f"{sp}struct{{{fields}}}"]
+    if isinstance(node, MapLiteral):
+        pairs = ', '.join(f"{dump_ast(k)[0].strip()}:{dump_ast(v)[0].strip()}" for k, v in node.pairs)
+        return [f"{sp}map{{{pairs}}}"]
+    if isinstance(node, SetLiteral):
+        elems = ', '.join(dump_ast(e)[0].strip() for e in node.elements)
+        return [f"{sp}set{{{elems}}}"]
+    if isinstance(node, UnaryOp):
+        return [f"{sp}{node.op}{dump_ast(node.operand)[0].strip()}"]
+    if isinstance(node, BinaryOp):
+        left = dump_ast(node.left)[0].strip()
+        right = dump_ast(node.right)[0].strip()
+        return [f"{sp}({left} {node.op} {right})"]
+    if isinstance(node, Input):
+        return [f"{sp}input {', '.join(node.names)}"]
+    if isinstance(node, Output):
+        exprs = ', '.join(dump_ast(e)[0].strip() for e in node.exprs)
+        return [f"{sp}output {exprs}"]
+    if isinstance(node, FuncCall):
+        args = ', '.join(dump_ast(a)[0].strip() for a in node.args)
+        return [f"{sp}{node.name}({args})"]
+    if isinstance(node, If):
+        lines = [f"{sp}if {dump_ast(node.cond)[0].strip()}:"]
+        for s in node.then.stmts:
+            lines.extend(dump_ast(s, indent + 2))
+        if node.else_:
+            lines.append(f"{sp}else:")
+            for s in node.else_.stmts:
+                lines.extend(dump_ast(s, indent + 2))
+        return lines
+    if isinstance(node, While):
+        lines = [f"{sp}while {dump_ast(node.cond)[0].strip()}:"]
+        for s in node.body.stmts:
+            lines.extend(dump_ast(s, indent + 2))
+        return lines
+    if isinstance(node, Return):
+        return [f"{sp}return {dump_ast(node.expr)[0].strip()}"]
+    raise RuntimeError('Unknown node')

--- a/report.md
+++ b/report.md
@@ -1,0 +1,86 @@
+# L25 编译器项目报告
+
+## 项目结构
+
+```
+VAANet/
+├── l25_compiler/                # L25 编译器源码
+│   ├── README.md                # 编译器使用说明
+│   ├── __init__.py              # 包导出
+│   ├── ast_nodes.py             # 抽象语法树节点定义
+│   ├── examples/                # 示例程序
+│   ├── gui.py                   # 图形界面
+│   ├── interpreter.py           # 解释执行器
+│   ├── ir.py                    # 文本化中间表示生成
+│   ├── lexer.py                 # 词法分析
+│   ├── main.py                  # 命令行入口
+│   ├── parser.py                # 语法分析
+│   ├── pcode.py                 # pcode 生成器
+│   ├── pcode_vm.py              # pcode 虚拟机
+│   ├── tac.py                   # 三地址码生成器
+│   └── utils.py                 # 辅助函数
+└── report.md                    # 实验报告(当前文件)
+```
+
+`examples/` 目录下包含 `factorial.l25`、`fibonacci.l25`、`sum.l25`、`array_struct.l25`、`pointer.l25`、`map_set.l25`、`complex_edge.l25` 与 `do_until.l25` 共八个测试程序。
+
+## 模块功能说明
+
+- **lexer.py**：利用正则表达式定义 `TOKEN_SPEC`，实现 `tokenize` 函数，将源代码拆分为 token 流，能够识别关键字、运算符、括号以及数组/结构体、map/set、指针相关符号。
+- **parser.py**：递归下降解析器，结合 `ast_nodes.py` 中的节点类构建抽象语法树。除基础语句外，还支持数组下标、结构体字段、指针地址与解引用、`map`/`set` 字面量，以及 `do...until` 循环等扩展语法。
+- **ast_nodes.py**：定义所有 AST 节点数据结构，如 `Program`、`FuncDef`、`Declare`、`ArrayLiteral`、`MapLiteral` 等。
+- **ir.py**：将 AST 转换为较易阅读的中间表示，保留语法结构便于调试。
+- **tac.py**：生成线性三地址码 (TAC)，便于后续优化或翻译。
+- **pcode.py**：将 AST 转为栈式 pcode 指令序列，作为虚拟机的输入。
+- **pcode_vm.py**：栈式虚拟机，实现变量环境、指针、数组/结构体和 map/set 操作等指令的执行。
+- **interpreter.py**：提供直接遍历 AST 的解释器，用于参考和测试。
+- **gui.py**：基于 Tkinter 的图形界面，可选择输出 Tokens、AST、IR、TAC、Pcode，并在右侧窗口显示运行结果。
+- **utils.py**：包含 AST 打印等辅助工具函数。
+- **main.py**：命令行接口，解析参数后调用以上模块完成编译和执行。
+
+## 编译流程
+
+1. **词法分析**：`lexer.tokenize` 将源代码转为 token 序列。
+2. **语法分析**：`parser.Parser` 根据 token 构建 AST。若语法错误则抛出异常。
+3. **中间代码生成**：
+   - `ir.IRGenerator` 生成结构化的 IR 文本。
+   - `tac.ThreeAddressGenerator` 生成三地址码。
+   - `pcode.PCodeGenerator` 生成栈式 pcode。
+4. **执行阶段**：`pcode_vm.PCodeVM` 读取 pcode，通过栈和变量环境完成指令解释，输出结果。
+5. 命令行或 GUI 均可选择输出任意阶段的中间结果，或直接运行程序。
+
+## 扩展功能实现
+
+在基础框架上实现了以下扩展：
+
+- **一维数组与结构体**：在 `parser.py` 增加数组声明 `let a[n]`、数组字面量 `[1,2]`、结构体字面量 `struct {x=1;}`，并在 `interpreter.py`、`pcode.py`、`pcode_vm.py` 等处处理下标和字段访问。
+- **指针支持**：引入 `&` 取地址与 `*` 解引用操作，虚拟机中用 `Pointer` 对象管理。示例 `pointer.l25` 展示了交换两个变量的程序。
+- **map/set 类型**：支持字典和集合字面量及若干内建函数，如 `map_insert`、`map_keys`、`set_add` 等，这些在虚拟机 `_builtins` 字典中实现。
+- **do-until 循环**：解析器新增 `do_until_stmt` 规则，生成对应的 pcode/TAC 指令。
+- **图形界面**：`gui.py` 提供中文界面，可加载 `.l25` 文件、选择输出阶段并运行程序；界面会在无输入时提醒用户，并在发生运行错误时保留已产生的输出。
+
+## 运行与验证
+
+1. **命令行使用**（示例）:
+   ```bash
+   # 编译并运行阶乘示例
+   python -m l25_compiler.main l25_compiler/examples/factorial.l25 <<EOF
+   5
+   EOF
+
+   # 查看所有中间代码但不执行
+   python -m l25_compiler.main --tokens --ast --ir --tac --pcode --no-run \
+       l25_compiler/examples/pointer.l25 | head
+   ```
+2. **图形界面**:
+   ```bash
+   python -m l25_compiler.gui
+   ```
+   在界面中加载任一 `.l25` 文件，可勾选需要展示的阶段，并在右侧看到运行结果。
+3. **测试示例**：`examples` 目录下的八个程序覆盖数组/结构体、指针、map/set、do-until 等特性。运行它们的输出应分别与 README 中描述一致，如
+   ```bash
+   python -m l25_compiler.main l25_compiler/examples/array_struct.l25
+   ```
+   得到：`3 5`。
+
+以上即为项目的整体设计与使用说明。


### PR DESCRIPTION
## Summary
- add `map` and `set` keywords and `:` token in the lexer
- implement `MapLiteral` and `SetLiteral` in AST and parser
- support map/set literals and helper functions in the interpreter
- extend IR/TAC generators and AST dumper for the new nodes
- document map/set features and provide `map_set.l25` example

## Testing
- `python -m py_compile l25_compiler/*.py`
- `python -m l25_compiler.main l25_compiler/examples/array_struct.l25`
- `python -m l25_compiler.main l25_compiler/examples/factorial.l25 <<EOF
5
EOF`
- `python -m l25_compiler.main l25_compiler/examples/fibonacci.l25 <<EOF
5
EOF`
- `python -m l25_compiler.main l25_compiler/examples/sum.l25 <<EOF
10
EOF`
- `python -m l25_compiler.main l25_compiler/examples/map_set.l25`
- `python -m l25_compiler.main l25_compiler/examples/pointer.l25`
- `python -m l25_compiler.main --tokens --ast --ir --tac --no-run l25_compiler/examples/map_set.l25 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684455ce064083318a1074477d5aa9f0